### PR TITLE
Fix openapi paths

### DIFF
--- a/READMEAR.md
+++ b/READMEAR.md
@@ -8,7 +8,7 @@
 
 ### 1.1 تحديث مواصفة OpenAPI
 
-- **المسار**: `demo/openapi.yaml`
+- **المسار**: `services/backend/src/main/resources/openapi.yaml`
 - **ماذا تفعل**: أضف قسمًا جديدًا تحت `paths` و`components.schemas` لتعريف endpoints وDTOs الخاصة بالميزة.
 
 ```yaml
@@ -42,7 +42,7 @@ components:
 
 ### 1.2 تكوين OpenAPI Generator في `pom.xml`
 
-- **المسار**: `demo/pom.xml`
+- **المسار**: `services/backend/pom.xml`
 - تحت `<build><plugins>...</plugins></build>`، أضف:
 
 ```xml
@@ -74,7 +74,7 @@ components:
 ### 1.3 توليد الكود والتحقق
 
 ```bash
-cd demo
+cd services/backend
 ./mvnw clean generate-sources compile
 ```
 - **التحقق**: تأكد من وجود الملفات المولدة في `target/generated-sources/openapi` مثل:

--- a/config.example.yml
+++ b/config.example.yml
@@ -8,4 +8,4 @@ exclude:
   - "pilot_app/**/*.g.dart"
 backup_dir: ".backups"
 backup_retention_days: 7
-generated_openapi: "demo/src/main/resources/openapi.yaml"
+generated_openapi: "services/backend/src/main/resources/openapi.yaml"

--- a/config.yml
+++ b/config.yml
@@ -9,4 +9,4 @@ exclude:
   - "pilot_app/**/*.g.dart"
 backup_dir: ".backups"
 backup_retention_days: 7
-generated_openapi: "demo/src/main/resources/openapi.yaml"
+generated_openapi: "services/backend/src/main/resources/openapi.yaml"

--- a/scripts/apply_changes.py
+++ b/scripts/apply_changes.py
@@ -119,7 +119,7 @@ if not _cmd_exists("git"):
     LOG.error("%s required tool 'git' not found in PATH.", ERR)
     sys.exit(3)
 
-MVNW = REPO_ROOT / "demo" / "mvnw"
+MVNW = REPO_ROOT / "services" / "backend" / "mvnw"
 FLUTTER = shutil.which("flutter")
 
 # ───────────────────────── 6. config.yml ─────────────────────────
@@ -150,7 +150,12 @@ include_patterns: List[str] = raw_cfg.get("include", ["**/*"])
 exclude_patterns: List[str] = raw_cfg.get("exclude", [])
 backup_dir = REPO_ROOT / raw_cfg.get("backup_dir", ".backups")
 retention_days: int = int(raw_cfg.get("backup_retention_days", 7))
-generated_openapi = Path(raw_cfg.get("generated_openapi", "demo/src/main/resources/openapi.yaml"))
+generated_openapi = Path(
+    raw_cfg.get(
+        "generated_openapi",
+        "services/backend/src/main/resources/openapi.yaml",
+    )
+)
 
 # always exclude backup directory (handle nested paths)
 rel_backup = backup_dir.relative_to(REPO_ROOT)
@@ -325,7 +330,7 @@ try:
     if touched_openapi:
         LOG.info("Detected change in %s – regenerating sources…", generated_openapi)
         if not MVNW.exists():
-            raise FileNotFoundError("mvnw wrapper not found in demo/")
+            raise FileNotFoundError("mvnw wrapper not found in services/backend/")
         _run([str(MVNW), "-q", "openapi-generator:generate"], cwd=MVNW.parent, quiet=True)
         _run([str(MVNW), "-q", "verify"], cwd=MVNW.parent, quiet=True)
         if FLUTTER:


### PR DESCRIPTION
## Summary
- update openapi path defaults
- fix READMEAR docs

## Testing
- `python3 -m py_compile scripts/apply_changes.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*