### PR TITLE
Rename Flutter app names

### DIFF
--- a/apps/admin_app/android/app/build.gradle.kts
+++ b/apps/admin_app/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.pilot.pilot_app"
+    namespace = "com.yourco.admin"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.pilot.pilot_app"
+        applicationId = "com.yourco.admin"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/apps/admin_app/android/app/src/main/AndroidManifest.xml
+++ b/apps/admin_app/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="pilot_app"
+        android:label="Admin App"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/apps/admin_app/android/app/src/main/kotlin/com/yourco/admin/MainActivity.kt
+++ b/apps/admin_app/android/app/src/main/kotlin/com/yourco/admin/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.pilot.pilot_app
+package com.yourco.admin
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/apps/admin_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/admin_app/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.admin;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.admin.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.admin.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.admin.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.admin;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.admin;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/apps/admin_app/ios/Runner/Info.plist
+++ b/apps/admin_app/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Pilot App</string>
+        <string>Admin App</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>pilot_app</string>
+        <string>admin_app</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/apps/admin_app/pubspec.yaml
+++ b/apps/admin_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: pilot_app
+name: admin_app
 description: A new Flutter project.
 publish_to: 'none'
 version: 1.0.0+1

--- a/apps/cleaner_app/android/app/build.gradle.kts
+++ b/apps/cleaner_app/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.pilot.pilot_app"
+    namespace = "com.yourco.cleaner"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.pilot.pilot_app"
+        applicationId = "com.yourco.cleaner"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/apps/cleaner_app/android/app/src/main/AndroidManifest.xml
+++ b/apps/cleaner_app/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="pilot_app"
+        android:label="Cleaner App"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/apps/cleaner_app/android/app/src/main/kotlin/com/yourco/cleaner/MainActivity.kt
+++ b/apps/cleaner_app/android/app/src/main/kotlin/com/yourco/cleaner/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.pilot.pilot_app
+package com.yourco.cleaner
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/apps/cleaner_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/cleaner_app/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.cleaner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.cleaner.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.cleaner.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.cleaner.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.cleaner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.cleaner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/apps/cleaner_app/ios/Runner/Info.plist
+++ b/apps/cleaner_app/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Pilot App</string>
+        <string>Cleaner App</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>pilot_app</string>
+        <string>cleaner_app</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/apps/cleaner_app/pubspec.yaml
+++ b/apps/cleaner_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: pilot_app
+name: cleaner_app
 description: A new Flutter project.
 publish_to: 'none'
 version: 1.0.0+1

--- a/apps/guest_app/android/app/build.gradle.kts
+++ b/apps/guest_app/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.pilot.pilot_app"
+    namespace = "com.yourco.guest"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.pilot.pilot_app"
+        applicationId = "com.yourco.guest"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/apps/guest_app/android/app/src/main/AndroidManifest.xml
+++ b/apps/guest_app/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="pilot_app"
+        android:label="Guest App"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/apps/guest_app/android/app/src/main/kotlin/com/yourco/guest/MainActivity.kt
+++ b/apps/guest_app/android/app/src/main/kotlin/com/yourco/guest/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.pilot.pilot_app
+package com.yourco.guest
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/apps/guest_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/guest_app/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.guest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.guest.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.guest.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.guest.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.guest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourco.guest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/apps/guest_app/ios/Runner/Info.plist
+++ b/apps/guest_app/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Pilot App</string>
+        <string>Guest App</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>pilot_app</string>
+        <string>guest_app</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/apps/guest_app/pubspec.yaml
+++ b/apps/guest_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: pilot_app
+name: guest_app
 description: A new Flutter project.
 publish_to: 'none'
 version: 1.0.0+1


### PR DESCRIPTION
## Summary
- rename each Flutter app with a specific name
- update bundle IDs and labels for Android and iOS

## Testing
- `pytest -q` *(fails: command not found)*