### PR TITLE
Add local UI kit and template API paths

### DIFF
--- a/apps/admin_app/pubspec.yaml
+++ b/apps/admin_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: pilot_app
+name: admin_app
 description: A new Flutter project.
 publish_to: 'none'
 version: 1.0.0+1
@@ -19,8 +19,10 @@ dependencies:
   go_router: ^7.0.1
   built_value: ^8.6.0      # أو آخر إصدار متاح
   built_collection: ^5.1.1 # إن لم تكن موجودة بهذا الرقم
+  ui_kit:
+    path: ../../packages/ui_kit
   template_api:
-    path: ../packages/template_api
+    path: ../../packages/template_api
 
 
 dev_dependencies:

--- a/apps/cleaner_app/pubspec.yaml
+++ b/apps/cleaner_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: pilot_app
+name: cleaner_app
 description: A new Flutter project.
 publish_to: 'none'
 version: 1.0.0+1
@@ -19,8 +19,10 @@ dependencies:
   go_router: ^7.0.1
   built_value: ^8.6.0      # أو آخر إصدار متاح
   built_collection: ^5.1.1 # إن لم تكن موجودة بهذا الرقم
+  ui_kit:
+    path: ../../packages/ui_kit
   template_api:
-    path: ../packages/template_api
+    path: ../../packages/template_api
 
 
 dev_dependencies:

--- a/apps/guest_app/pubspec.yaml
+++ b/apps/guest_app/pubspec.yaml
@@ -1,4 +1,4 @@
-name: pilot_app
+name: guest_app
 description: A new Flutter project.
 publish_to: 'none'
 version: 1.0.0+1
@@ -19,8 +19,10 @@ dependencies:
   go_router: ^7.0.1
   built_value: ^8.6.0      # أو آخر إصدار متاح
   built_collection: ^5.1.1 # إن لم تكن موجودة بهذا الرقم
+  ui_kit:
+    path: ../../packages/ui_kit
   template_api:
-    path: ../packages/template_api
+    path: ../../packages/template_api
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- reference ui_kit and template_api packages via relative paths in each Flutter app

## Testing
- `pytest -q` *(fails: command not found)*
- `git status --short`