### PR TITLE
Update CI for multi Flutter apps

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,6 +42,9 @@ jobs:
     name: Build & Test Flutter
     needs: backend
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [apps/guest_app, apps/admin_app, apps/cleaner_app]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Flutter
@@ -49,16 +52,16 @@ jobs:
         with:
           channel: 'stable'
       - name: Install dependencies
-        working-directory: pilot_app
+        working-directory: ${{ matrix.app }}
         run: flutter pub get
       - name: Generate code
-        working-directory: pilot_app
+        working-directory: ${{ matrix.app }}
         run: flutter pub run build_runner build --delete-conflicting-outputs
       - name: Analyze
-        working-directory: pilot_app
+        working-directory: ${{ matrix.app }}
         run: flutter analyze --fatal-warnings
       - name: Run tests
-        working-directory: pilot_app
+        working-directory: ${{ matrix.app }}
         run: flutter test
 ```
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,9 +29,12 @@ jobs:
           java-version: 17
           cache: maven
 
-      # تنظيف أي بقايا عميل Dart قديم داخل pilot_app (احتياط)
-      - name: 🧹 Remove obsolete generated client
-        run: rm -rf pilot_app/lib/generated
+      # تنظيف أي بقايا عميل Dart قديم لكل تطبيق Flutter (احتياط)
+      - name: 🧹 Remove obsolete generated clients
+        run: |
+          rm -rf apps/guest_app/lib/generated
+          rm -rf apps/admin_app/lib/generated
+          rm -rf apps/cleaner_app/lib/generated
 
       # يولّد stubs للـ Backend + Dart client في packages/template_api
       - name: 🔧 Generate OpenAPI stubs & Dart client
@@ -53,6 +56,12 @@ jobs:
     name: "Build & Test Flutter"
     needs: backend   # ينتظر نجاح الـ backend
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app:
+          - apps/guest_app
+          - apps/admin_app
+          - apps/cleaner_app
 
     steps:
       - name: ⬇️ Checkout repository
@@ -84,22 +93,22 @@ jobs:
         working-directory: packages/template_api
         run: flutter pub run build_runner build --delete-conflicting-outputs
 
-      # ─── Build pilot_app ──────────────────────────────────────────
-      - name: 📦 Install pilot_app dependencies
-        working-directory: pilot_app
+      # ─── Build Flutter app ${{ matrix.app }} ───────────────────────
+      - name: 📦 Install app dependencies
+        working-directory: ${{ matrix.app }}
         run: flutter pub get
 
       - name: 🔍 Static analysis (fatal‑warnings)
-        working-directory: pilot_app
+        working-directory: ${{ matrix.app }}
         run: flutter analyze --fatal-warnings
 
       - name: ✅ Run Flutter tests (with coverage)
-        working-directory: pilot_app
+        working-directory: ${{ matrix.app }}
         run: flutter test --coverage
 
       - name: 📊 Generate HTML coverage (lcov)
         if: success()
-        working-directory: pilot_app
+        working-directory: ${{ matrix.app }}
         run: |
           sudo apt-get update -y
           sudo apt-get install -y lcov

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Monorepo Template** is a starter project combining a **Spring Boot 3** backend and a **Flutter 3** frontend, unified by a shared **OpenAPI** contract. This template provides a fully working example of a monorepo architecture where the API specification is the single source of truth for both backend and frontend. By using OpenAPI-driven development, it ensures that your client and server are always in sync. It comes with a CI pipeline, code generation scripts, and a sample feature implementation to illustrate best practices. **Developers can fork this repository as a base** for their own projects, saving time on setup and focusing on features.
 
-&#x20;**Figure:** The Flutter frontend (`pilot_app`) running on desktop, showing a simple list of features (here just one sample entry). This UI is powered by data from the Spring Boot backend via the generated API client. For demonstration, the template includes minimal example modules (e.g. a sample user and booking domain) to use as a starting point. You can replace or extend these with your own modules and endpoints while retaining the provided project structure and integrations.
+&#x20;**Figure:** The Flutter frontend (`apps/guest_app`) running on desktop, showing a simple list of features (here just one sample entry). This UI is powered by data from the Spring Boot backend via the generated API client. For demonstration, the template includes minimal example modules (e.g. a sample user and booking domain) to use as a starting point. You can replace or extend these with your own modules and endpoints while retaining the provided project structure and integrations.
 
 ## Tech Stack
 
@@ -18,7 +18,7 @@
 
 * **Backend – Spring Boot Service** (`services/backend`): A self-contained Spring Boot project (Maven-based) that exposes RESTful APIs defined in the OpenAPI spec. The OpenAPI YAML file resides here at `services/backend/src/main/resources/openapi.yaml`. During the build, the OpenAPI Generator plugin auto-generates Java interfaces and models for the API (into `target/generated-sources/openapi`). The developer implements the API business logic by implementing these interfaces (or by writing controllers that fulfill the contract). For example, if the spec defines a `GET /feature` endpoint, the build will generate an interface (e.g. `FeatureApi`) with a method like `getFeatures()`, and a corresponding model class `FeatureDTO`. You then create a concrete Spring component (or use the provided stub) to handle the request (e.g. via a `@RestController` or service class). The backend is a typical Spring Boot app: it can be run standalone (it listens on port 8080 by default) and it’s configured for profile-based settings (e.g. see `SPRING_PROFILES_ACTIVE=dev` in Docker setup).
 
-* **Frontend – Flutter App** (`pilot_app`): A Flutter project that provides the user interface. It’s organized by feature modules (for example, you might have a `user` feature or a `booking` feature as in the sample). The Flutter app does not hardcode REST calls; instead, it uses a **generated Dart API client** to communicate with the backend. This client is provided by the shared package `template_api`. The app obtains an instance of an `ApiClient` (wrapping Dio) pointing to the backend’s base URL (configured as `http://localhost:8080` by default in `service_locator.dart`). All network calls go through this client, e.g., calling `client.get('/feature')` to fetch a list of features. The UI layer uses Riverpod state notifiers and providers to manage asynchronous data (loading, success, error states) from these API calls. The Flutter app included in the template is set up for web, mobile, or desktop deployment, and includes some example pages (e.g., a feature list page and a form page) to demonstrate usage of the API client and state management. (The screenshot above shows one of these sample pages.)
+* **Frontend – Flutter Apps** (`apps/guest_app`, `apps/admin_app`, `apps/cleaner_app`): A Flutter project that provides the user interface. It’s organized by feature modules (for example, you might have a `user` feature or a `booking` feature as in the sample). The Flutter app does not hardcode REST calls; instead, it uses a **generated Dart API client** to communicate with the backend. This client is provided by the shared package `template_api`. The app obtains an instance of an `ApiClient` (wrapping Dio) pointing to the backend’s base URL (configured as `http://localhost:8080` by default in `service_locator.dart`). All network calls go through this client, e.g., calling `client.get('/feature')` to fetch a list of features. The UI layer uses Riverpod state notifiers and providers to manage asynchronous data (loading, success, error states) from these API calls. The Flutter app included in the template is set up for web, mobile, or desktop deployment, and includes some example pages (e.g., a feature list page and a form page) to demonstrate usage of the API client and state management. (The screenshot above shows one of these sample pages.)
 
 * **Shared API Client – Dart Package** (`packages/template_api`): A Dart library generated from the OpenAPI spec, which the Flutter app depends on. This package (`template_api`) is produced by OpenAPI Generator using the **`dart-dio`** client generator. It contains Dart models (using built\_value or JSON serialization) and API classes that correspond to the backend endpoints. For instance, if the OpenAPI spec defines a `FeatureDTO` schema and a `/feature` endpoint, the `template_api` package will have a Dart class `FeatureDto` and a `DefaultApi` (or similarly named) class with methods like `getFeatures()` to call the API. The Flutter app adds `template_api` as a dependency (via a path reference in `pubspec.yaml`), so you can simply import and use these generated types and methods in your Flutter code. This ensures type-safe, OpenAPI-consistent calls from Dart to the Java backend. Whenever the OpenAPI spec changes, this package should be regenerated (see **Usage Guide** below) so that the frontend automatically adapts to the new API contract.
 
@@ -55,7 +55,7 @@ Using Docker Compose is the fastest way to spin up the backend without touching 
 2. **Run the Flutter App:** Docker Compose does not containerize the Flutter UI (since Flutter is typically run on your local device/emulator for development). To launch the Flutter app, open a new terminal on your host machine and run:
 
    ```bash
-   cd pilot_app
+   cd apps/guest_app
    flutter pub get
    flutter run
    ```
@@ -64,7 +64,7 @@ Using Docker Compose is the fastest way to spin up the backend without touching 
 
 3. *(Optional)* **Swagger UI:** With the backend running, you can access the auto-generated API docs at [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) (or a similar URL, depending on Springdoc configuration) to explore the available endpoints. The template’s OpenAPI spec is loaded there for interactive testing.
 
-> **Note:** If you run the Flutter app on an Android emulator, the hostname **localhost** in the app’s API base URL will not refer to your host machine. In that case, set the base URL to **[http://10.0.2.2:8080](http://10.0.2.2:8080)** (10.0.2.2 is a special IP that points to host PC from Android emulator). You can change this in `pilot_app/lib/core/di/service_locator.dart` when registering the `ApiClient`. For a real device connected via USB, use your PC’s IP address on the network. This ensures the Flutter app can reach the backend container.
+> **Note:** If you run the Flutter app on an Android emulator, the hostname **localhost** in the app’s API base URL will not refer to your host machine. In that case, set the base URL to **[http://10.0.2.2:8080](http://10.0.2.2:8080)** (10.0.2.2 is a special IP that points to host PC from Android emulator). You can change this in `apps/guest_app/lib/core/di/service_locator.dart` when registering the `ApiClient`. For a real device connected via USB, use your PC’s IP address on the network. This ensures the Flutter app can reach the backend container.
 
 ### Running Manually (Local Backend & Frontend)
 
@@ -84,7 +84,7 @@ This uses the Maven Wrapper to compile and launch the Spring Boot application. I
 In a second terminal, navigate to the Flutter app directory:
 
 ```bash
-cd pilot_app
+cd apps/guest_app
 flutter pub get            # install Flutter dependencies, including template_api
 flutter pub run build_runner build --delete-conflicting-outputs   # generate any missing code (if needed)
 flutter run
@@ -92,6 +92,6 @@ flutter run
 
 Ensure you have a simulator or device ready (or use `-d` to specify one). The Flutter app will launch and connect to the backend at `localhost:8080`. As with the Docker approach, if you want to use a mobile emulator, adjust the base URL to 10.0.2.2 as described above. The `build_runner` step will generate code for any `*.g.dart` or other build-runner tasks (for example, the `template_api` package uses built\_value, so running this ensures all serializer code is up to date). Now you can interact with the app and it will talk to the local Spring Boot server.
 
-**3. Testing:** Both backend and frontend come with tests. You can run backend tests with `./mvnw test` (in `services/backend`) which will also produce a test coverage report (see `services/backend/target/site/jacoco` after running). For the Flutter app, run `flutter test` in `pilot_app` to execute the Dart unit/widget tests. The CI pipeline runs these tests automatically on each commit.
+**3. Testing:** Both backend and frontend come with tests. You can run backend tests with `./mvnw test` (in `services/backend`) which will also produce a test coverage report (see `services/backend/target/site/jacoco` after running). For the Flutter app, run `flutter test` in `apps/guest_app` to execute the Dart unit/widget tests. The CI pipeline runs these tests automatically on each commit.
 
 ---

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,7 +34,7 @@ This script runs the OpenAPI Generator CLI (via Docker) to generate a Dart clien
   ```
 
   This will generate any missing part files (e.g., serializers or built\_value generated code).
-* Finally, run `flutter pub get` in `pilot_app` as well, to ensure the app picks up the updated `template_api` package (if the package version or content changed, the path dependency will be refreshed).
+* Finally, run `flutter pub get` in `apps/guest_app` as well, to ensure the app picks up the updated `template_api` package (if the package version or content changed, the path dependency will be refreshed).
 
 After these steps, the Flutter app’s code can immediately use the new API calls or models defined in the updated spec. For example, if you added a `/feature` endpoint, the `template_api` might now have a new method `DefaultApi().getFeatures()` and a model class `FeatureDto` to use in your Dart code.
 
@@ -90,7 +90,7 @@ To illustrate how you would extend this template, let’s walk through adding a 
      Don’t forget to update the security configuration if your new endpoint needs role-based protection (see `SecurityConfig`, where you can add a rule for your `/feature` path). Also consider adding unit tests for your new service or controller.
 
 * **Step 4: Use the new endpoint in the Flutter app.**
-  With the backend providing data and the `template_api` Dart client updated, you can now call the new API from Flutter. Typically, you’d create a new “feature” module in the `pilot_app/lib/features` directory (analogous to the existing examples like `user` or `transport`). For instance:
+  With the backend providing data and the `template_api` Dart client updated, you can now call the new API from Flutter. Typically, you’d create a new “feature” module in the `apps/guest_app/lib/features` directory (analogous to the existing examples like `user` or `transport`). For instance:
 
   * Create a Dart model class if needed (though you might use the generated `FeatureDto` from `template_api` directly, or define a simpler app-specific model). The template demonstrates both approaches – in some cases, you might use `template_api` models directly, or use `json_serializable` to define Flutter-side models.
   * Set up a data source or repository class to call the API. For example, a `FeatureRemoteDataSource` that calls `ApiClient.get('/feature')` or uses the generated client method. In our sample, the data source might call `templateApi.getFeatures()` and convert the result to your Flutter `FeatureModel`.
@@ -102,7 +102,7 @@ After following these steps, your new **Feature** functionality would be fully i
 
 ## Tips for Forking and Customization
 
-* **Renaming the Project:** If you fork this repository for your own project, you’ll likely want to change package names, remove the sample features, and adjust branding. The Java backend’s base package is `com.example.app` (and sometimes `com.example.demo` in placeholders) – you should replace this with your own domain (e.g., `com.mycompany.myapp`). Similarly, rename the Flutter app (currently `pilot_app`) to your app’s name and update its `pubspec.yaml` (name, bundle identifier, etc.). Search the codebase for “example” or “template” to find placeholders to replace. Renaming can be done manually or by using the provided `scripts/apply_changes.py` which can batch-apply name changes as per a config (advanced usage).
+* **Renaming the Project:** If you fork this repository for your own project, you’ll likely want to change package names, remove the sample features, and adjust branding. The Java backend’s base package is `com.example.app` (and sometimes `com.example.demo` in placeholders) – you should replace this with your own domain (e.g., `com.mycompany.myapp`). Similarly, rename the Flutter app (currently `apps/guest_app`) to your app’s name and update its `pubspec.yaml` (name, bundle identifier, etc.). Search the codebase for “example” or “template” to find placeholders to replace. Renaming can be done manually or by using the provided `scripts/apply_changes.py` which can batch-apply name changes as per a config (advanced usage).
 * **Removing Sample Code:** The template includes some sample domain logic (such as a stubbed booking/payment feature and an auth stub, as seen in the codebase) to illustrate patterns. You can safely delete or replace these with your own features. Just ensure to remove their routes from the OpenAPI spec if you’re not using them, and regenerate the code to avoid leftover references.
 * **Adding a Database:** The Docker Compose file has an example PostgreSQL service commented out. If your feature needs a database, you can uncomment and adjust this. The backend is already set up with Spring Data JPA and Flyway, so you can write entities and repositories. Update `application-dev.yaml` (or equivalent config) with the DB connection info and add Flyway migration scripts in `resources/db/migration` if needed.
 * **API Versioning and URL Prefix:** By default, the OpenAPI spec and controllers use paths like `/feature`. In a real project, you might want them under a versioned API prefix, e.g., `/api/v1/feature`. You can adjust this in the OpenAPI spec (add a `servers` block with a base path) or via Spring configuration. The template doesn’t enforce a prefix, but it’s a good practice to add before going to production.

--- a/config.example.yml
+++ b/config.example.yml
@@ -2,10 +2,14 @@ include:
   - "demo/**"
   - "demo/src/main/java/**"
   - "demo/src/main/java/com/example/demo/entity/BookingEntity.java"
-  - "pilot_app/**"
+  - "apps/guest_app/**"
+  - "apps/admin_app/**"
+  - "apps/cleaner_app/**"
 exclude:
   - "demo/target/generated-sources/**"
-  - "pilot_app/**/*.g.dart"
+  - "apps/guest_app/**/*.g.dart"
+  - "apps/admin_app/**/*.g.dart"
+  - "apps/cleaner_app/**/*.g.dart"
 backup_dir: ".backups"
 backup_retention_days: 7
 generated_openapi: "services/backend/src/main/resources/openapi.yaml"

--- a/config.yml
+++ b/config.yml
@@ -1,12 +1,16 @@
 include:
   - "demo/**"
-  - "pilot_app/**"
+  - "apps/guest_app/**"
+  - "apps/admin_app/**"
+  - "apps/cleaner_app/**"
   - "demo/src/main/java/**"
   - "demo/src/main/java/com/example/demo/entity/BookingEntity.java"
   - "config.yml"
 exclude:
   - "demo/target/generated-sources/**"
-  - "pilot_app/**/*.g.dart"
+  - "apps/guest_app/**/*.g.dart"
+  - "apps/admin_app/**/*.g.dart"
+  - "apps/cleaner_app/**/*.g.dart"
 backup_dir: ".backups"
 backup_retention_days: 7
 generated_openapi: "services/backend/src/main/resources/openapi.yaml"

--- a/scripts/generate_api_client.sh
+++ b/scripts/generate_api_client.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 GEN_VERSION="6.6.0"
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 
-# 🧹 احذف أي عميل Dart قديم داخل pilot_app
-rm -rf "${PROJECT_ROOT}/pilot_app/lib/generated"
+# 🧹 احذف أي عميل Dart قديم داخل كل تطبيق Flutter
+rm -rf "${PROJECT_ROOT}/apps/guest_app/lib/generated"
+rm -rf "${PROJECT_ROOT}/apps/admin_app/lib/generated"
+rm -rf "${PROJECT_ROOT}/apps/cleaner_app/lib/generated"
 
 # مجلد إخراج الحزمة الجديدة
 OUT="${PROJECT_ROOT}/packages/template_api"


### PR DESCRIPTION
## Summary
- adjust CI workflow to use matrix with multiple Flutter apps
- update workflow README snippet for matrix usage
- update docs and usage guide to reference apps/guest_app
- update config files to include new app paths
- clean Dart client directories for all apps in generation script

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*