### PR TITLE
Fix imports after renaming Flutter apps

### DIFF
--- a/apps/admin_app/integration_test/app_test.dart
+++ b/apps/admin_app/integration_test/app_test.dart
@@ -7,7 +7,7 @@ import 'package:integration_test/integration_test.dart';
 // استورد الملف الذي يشغّل تطبيقك عادةً
 // عادةً نضعه بهذا الشكل إن كان لديك ملف main.dart
 // تحتوي على void main() => runApp(MyApp());
-import 'package:pilot_app/main.dart' as app;
+import 'package:admin_app/main.dart' as app;
 
 void main() {
   // Binding لاختبارات التكامل

--- a/apps/admin_app/test/api_client_mock.dart
+++ b/apps/admin_app/test/api_client_mock.dart
@@ -1,4 +1,4 @@
 import 'package:mocktail/mocktail.dart';
-import 'package:pilot_app/core/network/api_client.dart';
+import 'package:admin_app/core/network/api_client.dart';
 
 class MockApiClient extends Mock implements ApiClient {}

--- a/apps/admin_app/test/feature_page_test.dart
+++ b/apps/admin_app/test/feature_page_test.dart
@@ -5,7 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:template_api/template_api.dart';
 
-import 'package:pilot_app/features/feature/feature_page.dart';
+import 'package:admin_app/features/feature/feature_page.dart';
 
 class _MockApi extends Mock implements DefaultApi {}
 

--- a/apps/cleaner_app/integration_test/app_test.dart
+++ b/apps/cleaner_app/integration_test/app_test.dart
@@ -7,7 +7,7 @@ import 'package:integration_test/integration_test.dart';
 // استورد الملف الذي يشغّل تطبيقك عادةً
 // عادةً نضعه بهذا الشكل إن كان لديك ملف main.dart
 // تحتوي على void main() => runApp(MyApp());
-import 'package:pilot_app/main.dart' as app;
+import 'package:cleaner_app/main.dart' as app;
 
 void main() {
   // Binding لاختبارات التكامل

--- a/apps/cleaner_app/test/api_client_mock.dart
+++ b/apps/cleaner_app/test/api_client_mock.dart
@@ -1,4 +1,4 @@
 import 'package:mocktail/mocktail.dart';
-import 'package:pilot_app/core/network/api_client.dart';
+import 'package:cleaner_app/core/network/api_client.dart';
 
 class MockApiClient extends Mock implements ApiClient {}

--- a/apps/cleaner_app/test/feature_page_test.dart
+++ b/apps/cleaner_app/test/feature_page_test.dart
@@ -5,7 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:template_api/template_api.dart';
 
-import 'package:pilot_app/features/feature/feature_page.dart';
+import 'package:cleaner_app/features/feature/feature_page.dart';
 
 class _MockApi extends Mock implements DefaultApi {}
 

--- a/apps/guest_app/integration_test/app_test.dart
+++ b/apps/guest_app/integration_test/app_test.dart
@@ -7,7 +7,7 @@ import 'package:integration_test/integration_test.dart';
 // استورد الملف الذي يشغّل تطبيقك عادةً
 // عادةً نضعه بهذا الشكل إن كان لديك ملف main.dart
 // تحتوي على void main() => runApp(MyApp());
-import 'package:pilot_app/main.dart' as app;
+import 'package:guest_app/main.dart' as app;
 
 void main() {
   // Binding لاختبارات التكامل

--- a/apps/guest_app/test/api_client_mock.dart
+++ b/apps/guest_app/test/api_client_mock.dart
@@ -1,4 +1,4 @@
 import 'package:mocktail/mocktail.dart';
-import 'package:pilot_app/core/network/api_client.dart';
+import 'package:guest_app/core/network/api_client.dart';
 
 class MockApiClient extends Mock implements ApiClient {}

--- a/apps/guest_app/test/feature_page_test.dart
+++ b/apps/guest_app/test/feature_page_test.dart
@@ -5,7 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:template_api/template_api.dart';
 
-import 'package:pilot_app/features/feature/feature_page.dart';
+import 'package:guest_app/features/feature/feature_page.dart';
 
 class _MockApi extends Mock implements DefaultApi {}
 


### PR DESCRIPTION
## Summary
- update Dart tests to import from new package names

## Testing
- `grep -R "package:pilot_app" -n`