### PR TITLE
Fix widget tests to use PilotApp

### DIFF
--- a/apps/admin_app/test/widget_test.dart
+++ b/apps/admin_app/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:admin_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const PilotApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);

--- a/apps/cleaner_app/test/widget_test.dart
+++ b/apps/cleaner_app/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:cleaner_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const PilotApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);

--- a/apps/guest_app/test/widget_test.dart
+++ b/apps/guest_app/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:guest_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const PilotApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- ensure each app's widget test pumps `PilotApp`

## Testing
- `flutter analyze --fatal-warnings` *(fails: `flutter` command not found)*