### PR TITLE
Update app names for platform builds

### DIFF
--- a/apps/admin_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/apps/admin_app/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* pilot_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "pilot_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* admin_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "admin_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* pilot_app.app */,
+				33CC10ED2044A3C60003C045 /* admin_app.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* pilot_app.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* admin_app.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -388,7 +388,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/admin_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/admin_app";
 			};
 			name = Debug;
 		};
@@ -402,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/admin_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/admin_app";
 			};
 			name = Release;
 		};
@@ -416,7 +416,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/admin_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/admin_app";
 			};
 			name = Profile;
 		};

--- a/apps/admin_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/apps/admin_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "pilot_app.app"
+               BuildableName = "admin_app.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "admin_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "admin_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "admin_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/apps/admin_app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/apps/admin_app/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = pilot_app
+PRODUCT_NAME = admin_app
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp

--- a/apps/admin_app/windows/CMakeLists.txt
+++ b/apps/admin_app/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(pilot_app LANGUAGES CXX)
+project(admin_app LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "pilot_app")
+set(BINARY_NAME "admin_app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/apps/admin_app/windows/runner/Runner.rc
+++ b/apps/admin_app/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.pilot" "\0"
-            VALUE "FileDescription", "pilot_app" "\0"
+            VALUE "FileDescription", "admin_app" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "pilot_app" "\0"
+            VALUE "InternalName", "admin_app" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.pilot. All rights reserved." "\0"
-            VALUE "OriginalFilename", "pilot_app.exe" "\0"
-            VALUE "ProductName", "pilot_app" "\0"
+            VALUE "OriginalFilename", "admin_app.exe" "\0"
+            VALUE "ProductName", "admin_app" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/apps/admin_app/windows/runner/main.cpp
+++ b/apps/admin_app/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"pilot_app", origin, size)) {
+  if (!window.Create(L"admin_app", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);

--- a/apps/cleaner_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/apps/cleaner_app/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* pilot_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "pilot_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* cleaner_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "cleaner_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* pilot_app.app */,
+				33CC10ED2044A3C60003C045 /* cleaner_app.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* pilot_app.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* cleaner_app.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -388,7 +388,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/cleaner_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/cleaner_app";
 			};
 			name = Debug;
 		};
@@ -402,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/cleaner_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/cleaner_app";
 			};
 			name = Release;
 		};
@@ -416,7 +416,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/cleaner_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/cleaner_app";
 			};
 			name = Profile;
 		};

--- a/apps/cleaner_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/apps/cleaner_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "pilot_app.app"
+               BuildableName = "cleaner_app.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "cleaner_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "cleaner_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "cleaner_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/apps/cleaner_app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/apps/cleaner_app/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = pilot_app
+PRODUCT_NAME = cleaner_app
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp

--- a/apps/cleaner_app/windows/CMakeLists.txt
+++ b/apps/cleaner_app/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(pilot_app LANGUAGES CXX)
+project(cleaner_app LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "pilot_app")
+set(BINARY_NAME "cleaner_app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/apps/cleaner_app/windows/runner/Runner.rc
+++ b/apps/cleaner_app/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.pilot" "\0"
-            VALUE "FileDescription", "pilot_app" "\0"
+            VALUE "FileDescription", "cleaner_app" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "pilot_app" "\0"
+            VALUE "InternalName", "cleaner_app" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.pilot. All rights reserved." "\0"
-            VALUE "OriginalFilename", "pilot_app.exe" "\0"
-            VALUE "ProductName", "pilot_app" "\0"
+            VALUE "OriginalFilename", "cleaner_app.exe" "\0"
+            VALUE "ProductName", "cleaner_app" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/apps/cleaner_app/windows/runner/main.cpp
+++ b/apps/cleaner_app/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"pilot_app", origin, size)) {
+  if (!window.Create(L"cleaner_app", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);

--- a/apps/guest_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/apps/guest_app/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* pilot_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "pilot_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* guest_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "guest_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* pilot_app.app */,
+				33CC10ED2044A3C60003C045 /* guest_app.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* pilot_app.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* guest_app.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -388,7 +388,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/guest_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/guest_app";
 			};
 			name = Debug;
 		};
@@ -402,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/guest_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/guest_app";
 			};
 			name = Release;
 		};
@@ -416,7 +416,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/pilot_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/pilot_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/guest_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/guest_app";
 			};
 			name = Profile;
 		};

--- a/apps/guest_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/apps/guest_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "pilot_app.app"
+               BuildableName = "guest_app.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "guest_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "guest_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "pilot_app.app"
+            BuildableName = "guest_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/apps/guest_app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/apps/guest_app/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = pilot_app
+PRODUCT_NAME = guest_app
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.pilot.pilotApp

--- a/apps/guest_app/windows/CMakeLists.txt
+++ b/apps/guest_app/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(pilot_app LANGUAGES CXX)
+project(guest_app LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "pilot_app")
+set(BINARY_NAME "guest_app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/apps/guest_app/windows/runner/Runner.rc
+++ b/apps/guest_app/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.pilot" "\0"
-            VALUE "FileDescription", "pilot_app" "\0"
+            VALUE "FileDescription", "guest_app" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "pilot_app" "\0"
+            VALUE "InternalName", "guest_app" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.pilot. All rights reserved." "\0"
-            VALUE "OriginalFilename", "pilot_app.exe" "\0"
-            VALUE "ProductName", "pilot_app" "\0"
+            VALUE "OriginalFilename", "guest_app.exe" "\0"
+            VALUE "ProductName", "guest_app" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/apps/guest_app/windows/runner/main.cpp
+++ b/apps/guest_app/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"pilot_app", origin, size)) {
+  if (!window.Create(L"guest_app", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
- fix Windows CMake to use each app name
- update Windows resource and main files
- adjust macOS configs and Xcode projects for proper app names

## Testing
- `grep -r "pilot_app" apps/*_app/windows apps/*_app/macos`