### PR TITLE
Update scripts for multi app support

### DIFF
--- a/scripts/apply_changes.py
+++ b/scripts/apply_changes.py
@@ -334,18 +334,20 @@ try:
         _run([str(MVNW), "-q", "openapi-generator:generate"], cwd=MVNW.parent, quiet=True)
         _run([str(MVNW), "-q", "verify"], cwd=MVNW.parent, quiet=True)
         if FLUTTER:
-            _run(
-                [
-                    FLUTTER,
-                    "pub",
-                    "run",
-                    "build_runner",
-                    "build",
-                    "--delete-conflicting-outputs",
-                ],
-                cwd=REPO_ROOT / "pilot_app",
-                quiet=True,
-            )
+            apps_root = REPO_ROOT / "apps"
+            for app_dir in apps_root.glob("*_app"):
+                _run(
+                    [
+                        FLUTTER,
+                        "pub",
+                        "run",
+                        "build_runner",
+                        "build",
+                        "--delete-conflicting-outputs",
+                    ],
+                    cwd=app_dir,
+                    quiet=True,
+                )
         else:
             LOG.warning("%s flutter not found – skipping Dart rebuild.", WARN)
 

--- a/scripts/generate_api_client.sh
+++ b/scripts/generate_api_client.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 GEN_VERSION="6.6.0"
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
 
-# 🧹 احذف أي عميل Dart قديم داخل pilot_app
-rm -rf "${PROJECT_ROOT}/pilot_app/lib/generated"
+# 🧹 احذف أي عميل Dart قديم داخل جميع التطبيقات
+for app in "${PROJECT_ROOT}"/apps/*_app; do
+  rm -rf "${app}/lib/generated"
+done
 
 # مجلد إخراج الحزمة الجديدة
 OUT="${PROJECT_ROOT}/packages/template_api"

--- a/scripts/new_project.sh
+++ b/scripts/new_project.sh
@@ -99,16 +99,22 @@ done
 
 # ── Flutter side ──────────────────────────────────────────────────────────────
 if ! $SKIP_FLUTTER; then
-  sedit "s/^name: .*/name: $PROJECT_NAME/" pilot_app/pubspec.yaml
-  sedit "s/^description: .*/description: $PROJECT_NAME app/" pilot_app/pubspec.yaml
-  info "Updating Dart client imports…"
-  grep -rl "$TEMPLATE_PKG" pilot_app | while read -r f; do sedit "s#$TEMPLATE_PKG#$NEW_API_PKG#g" "$f"; done
+  for app in apps/*_app; do
+    sedit "s/^name: .*/name: $PROJECT_NAME/" "$app/pubspec.yaml"
+    sedit "s/^description: .*/description: $PROJECT_NAME app/" "$app/pubspec.yaml"
+    info "Updating Dart client imports in $app…"
+    grep -rl "$TEMPLATE_PKG" "$app" | while read -r f; do
+      sedit "s#$TEMPLATE_PKG#$NEW_API_PKG#g" "$f"
+    done
+  done
 fi
 
 # ── optional cleanup ──────────────────────────────────────────────────────────
 if $REMOVE_SAMPLES; then
   info "Removing template sample features & tests…"
-  rm -rf pilot_app/lib/features/{user,transport} 2>/dev/null || true
+  for app in apps/*_app; do
+    rm -rf "$app"/lib/features/{user,transport} 2>/dev/null || true
+  done
   find services/backend/src/main/java -name FeatureController.java -delete
   find services/backend/src/test/java -name TemplateApplicationTests.java -delete
 fi
@@ -127,6 +133,7 @@ if $INIT_GIT; then git init -q; git add .; git commit -qm "Initial commit from t
 info "🎉  Project ready at '$DEST'.  Next steps:"
 echo "   cd \"$DEST\""
 echo "   mvn -f services/backend spring-boot:run   # backend"
-$SKIP_FLUTTER || echo "   cd pilot_app && flutter run               # Flutter"
+FIRST_APP=$(find apps -maxdepth 1 -name '*_app' | head -n1)
+$SKIP_FLUTTER || echo "   cd ${FIRST_APP} && flutter run               # Flutter"
 
 exit 0


### PR DESCRIPTION
## Summary
- clean generated clients in all apps before regenerate
- run build_runner in each app during apply_changes
- iterate over app folders in new_project script

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*