### PR TITLE
Fix widget tests to use correct app classes

### DIFF
--- a/apps/admin_app/test/widget_test.dart
+++ b/apps/admin_app/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:admin_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const PilotApp());
+    await tester.pumpWidget(const AdminApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);

--- a/apps/cleaner_app/test/widget_test.dart
+++ b/apps/cleaner_app/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:cleaner_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const PilotApp());
+    await tester.pumpWidget(const CleanerApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);

--- a/apps/guest_app/test/widget_test.dart
+++ b/apps/guest_app/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:guest_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const PilotApp());
+    await tester.pumpWidget(const GuestApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- fix guest app widget test to use `GuestApp`
- fix admin app widget test to use `AdminApp`
- fix cleaner app widget test to use `CleanerApp`

## Testing
- `git status --short`