### PR TITLE
Add agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guide for Code Agents
+
+- **Tests:** Always run `pytest -q` before committing. If you modify the backend or frontend, also run `./mvnw test` in `services/backend` and `flutter test` in `apps/guest_app`.
+- **OpenAPI Updates:** After editing `services/backend/src/main/resources/openapi.yaml`, run `./scripts/generate.sh` to regenerate the Java stubs and Dart client.
+- **Commit Messages:** Use short, present-tense summaries (e.g., "Add CI workflow").

--- a/README.md
+++ b/README.md
@@ -95,3 +95,5 @@ Ensure you have a simulator or device ready (or use `-d` to specify one). The Fl
 **3. Testing:** Both backend and frontend come with tests. You can run backend tests with `./mvnw test` (in `services/backend`) which will also produce a test coverage report (see `services/backend/target/site/jacoco` after running). For the Flutter app, run `flutter test` in `guest_app` to execute the Dart unit/widget tests. The CI pipeline runs these tests automatically on each commit.
 
 ---
+## Agent Guidelines
+See `AGENTS.md` for automated contributor rules. In short, run `pytest -q` before committing and regenerate OpenAPI clients with `./scripts/generate.sh` whenever you modify the spec.


### PR DESCRIPTION
## Summary
- create `AGENTS.md` with rules for automated contributors
- mention agent guidelines in README

## Testing
- `pytest -q` *(fails: command not found)*