### PR TITLE
Implement properties CRUD

### DIFF
--- a/services/backend/src/main/java/com/example/app/controller/PropertyController.java
+++ b/services/backend/src/main/java/com/example/app/controller/PropertyController.java
@@ -1,0 +1,91 @@
+package com.example.app.controller;
+
+import com.example.app.api.DefaultApi;
+import com.example.app.model.PropertyDTO;
+import com.example.app.property.PropertyEntity;
+import com.example.app.property.PropertyService;
+import com.example.app.user.UserEntity;
+import com.example.app.user.UserRepository;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PropertyController implements DefaultApi {
+
+  private final PropertyService propertyService;
+  private final UserRepository userRepository;
+
+  public PropertyController(PropertyService propertyService, UserRepository userRepository) {
+    this.propertyService = propertyService;
+    this.userRepository = userRepository;
+  }
+
+  @Override
+  public ResponseEntity<List<PropertyDTO>> propertiesGet(Long ownerId) {
+    List<PropertyDTO> list = propertyService.findAll(ownerId).stream()
+        .map(e -> new PropertyDTO()
+            .id(e.getId())
+            .name(e.getName())
+            .address(e.getAddress())
+            .ownerId(e.getOwner().getId()))
+        .collect(Collectors.toList());
+    return ResponseEntity.ok(list);
+  }
+
+  @Override
+  public ResponseEntity<Void> propertiesPost(@Valid PropertyDTO propertyDTO) {
+    UserEntity owner = userRepository.findById(propertyDTO.getOwnerId()).orElse(null);
+    if (owner == null) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+    PropertyEntity entity = new PropertyEntity(
+        null,
+        propertyDTO.getName(),
+        propertyDTO.getAddress(),
+        owner);
+    propertyService.create(entity);
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  @Override
+  public ResponseEntity<PropertyDTO> propertiesIdGet(Long id) {
+    return propertyService.findById(id)
+        .map(e -> new PropertyDTO()
+            .id(e.getId())
+            .name(e.getName())
+            .address(e.getAddress())
+            .ownerId(e.getOwner().getId()))
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  @Override
+  public ResponseEntity<PropertyDTO> propertiesIdPut(Long id, @Valid PropertyDTO propertyDTO) {
+    UserEntity owner = userRepository.findById(propertyDTO.getOwnerId()).orElse(null);
+    if (owner == null) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+    PropertyEntity entity = new PropertyEntity(
+        id,
+        propertyDTO.getName(),
+        propertyDTO.getAddress(),
+        owner);
+    PropertyEntity updated = propertyService.update(entity);
+    PropertyDTO dto = new PropertyDTO()
+        .id(updated.getId())
+        .name(updated.getName())
+        .address(updated.getAddress())
+        .ownerId(updated.getOwner().getId());
+    return ResponseEntity.ok(dto);
+  }
+
+  @Override
+  public ResponseEntity<Void> propertiesIdDelete(Long id) {
+    propertyService.delete(id);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/services/backend/src/main/java/com/example/app/property/PropertyRepository.java
+++ b/services/backend/src/main/java/com/example/app/property/PropertyRepository.java
@@ -1,5 +1,8 @@
 package com.example.app.property;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
-public interface PropertyRepository extends JpaRepository<PropertyEntity, Long> {}
+public interface PropertyRepository extends JpaRepository<PropertyEntity, Long> {
+  List<PropertyEntity> findByOwnerId(Long ownerId);
+}

--- a/services/backend/src/main/java/com/example/app/property/PropertyService.java
+++ b/services/backend/src/main/java/com/example/app/property/PropertyService.java
@@ -1,0 +1,38 @@
+package com.example.app.property;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PropertyService {
+
+  private final PropertyRepository propertyRepository;
+
+  public PropertyService(PropertyRepository propertyRepository) {
+    this.propertyRepository = propertyRepository;
+  }
+
+  public PropertyEntity create(PropertyEntity property) {
+    return propertyRepository.save(property);
+  }
+
+  public List<PropertyEntity> findAll(Long ownerId) {
+    if (ownerId != null) {
+      return propertyRepository.findByOwnerId(ownerId);
+    }
+    return propertyRepository.findAll();
+  }
+
+  public Optional<PropertyEntity> findById(Long id) {
+    return propertyRepository.findById(id);
+  }
+
+  public PropertyEntity update(PropertyEntity property) {
+    return propertyRepository.save(property);
+  }
+
+  public void delete(Long id) {
+    propertyRepository.deleteById(id);
+  }
+}

--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -63,6 +63,84 @@ paths:
       responses:
         '201':
           description: "Created"
+
+  /properties:
+    get:
+      summary: "List properties"
+      parameters:
+        - in: query
+          name: ownerId
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PropertyDTO'
+    post:
+      summary: "Create property"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertyDTO'
+      responses:
+        '201':
+          description: "Created"
+
+  /properties/{id}:
+    get:
+      summary: "Get property"
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PropertyDTO'
+    put:
+      summary: "Update property"
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PropertyDTO'
+      responses:
+        '200':
+          description: "Success"
+    delete:
+      summary: "Delete property"
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: "Deleted"
 components:
   schemas:
     FeatureDTO:
@@ -96,3 +174,20 @@ components:
         - GUEST
         - ADMIN
         - CLEANER
+    PropertyDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        address:
+          type: string
+        ownerId:
+          type: integer
+          format: int64
+      required:
+        - name
+        - address
+        - ownerId

--- a/services/backend/src/test/java/com/example/app/TemplateApplicationTests.java
+++ b/services/backend/src/test/java/com/example/app/TemplateApplicationTests.java
@@ -40,4 +40,19 @@ public class TemplateApplicationTests {
         .andExpect(jsonPath("$[0].email").value("a@example.com"))
         .andExpect(jsonPath("$[0].passwordHash").doesNotExist());
   }
+
+  @Test
+  public void testCreateAndListProperties() throws Exception {
+    String userBody = "{\"role\":\"GUEST\",\"email\":\"prop@example.com\",\"passwordHash\":\"x\"}";
+    mockMvc.perform(post("/users").contentType("application/json").content(userBody))
+        .andExpect(status().isCreated());
+
+    String propBody = "{\"name\":\"House\",\"address\":\"123 St\",\"ownerId\":1}";
+    mockMvc.perform(post("/properties").contentType("application/json").content(propBody))
+        .andExpect(status().isCreated());
+
+    mockMvc.perform(get("/properties").param("ownerId", "1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].name").value("House"));
+  }
 }


### PR DESCRIPTION
## Summary
- define PropertyDTO and CRUD endpoints in `openapi.yaml`
- add `PropertyService` and `PropertyController`
- extend `PropertyRepository` with owner filter
- cover property flow in `TemplateApplicationTests`

## Testing
- `pytest -q` *(fails: command not found)*
- `services/backend/mvnw clean verify` *(fails: cannot fetch maven)*