### PR TITLE
Add bookings API

### DIFF
--- a/services/backend/src/main/java/com/example/app/booking/BookingController.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingController.java
@@ -1,0 +1,100 @@
+package com.example.app.booking;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import com.example.app.property.PropertyEntity;
+import com.example.app.user.UserEntity;
+import com.example.app.booking.BookingEntity;
+import com.example.app.booking.BookingService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/bookings")
+public class BookingController {
+
+  private final BookingService bookingService;
+
+  public BookingController(BookingService bookingService) {
+    this.bookingService = bookingService;
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> create(@Valid @RequestBody BookingDTO dto) {
+    bookingService.create(toEntity(dto));
+    return ResponseEntity.status(HttpStatus.CREATED).build();
+  }
+
+  @GetMapping
+  public ResponseEntity<List<BookingDTO>> list(
+      @RequestParam(required = false) Long propertyId,
+      @RequestParam(required = false) Long userId) {
+    List<BookingEntity> entities =
+        bookingService.findAll(Optional.ofNullable(propertyId), Optional.ofNullable(userId));
+    List<BookingDTO> dtos = entities.stream().map(this::toDto).collect(Collectors.toList());
+    return ResponseEntity.ok(dtos);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<BookingDTO> get(@PathVariable Long id) {
+    BookingEntity entity = bookingService.findById(id);
+    if (entity == null) {
+      return ResponseEntity.notFound().build();
+    }
+    return ResponseEntity.ok(toDto(entity));
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<BookingDTO> update(@PathVariable Long id, @Valid @RequestBody BookingDTO dto) {
+    BookingEntity existing = bookingService.findById(id);
+    if (existing == null) {
+      return ResponseEntity.notFound().build();
+    }
+    BookingEntity toUpdate = toEntity(dto);
+    toUpdate.setId(id);
+    BookingEntity saved = bookingService.update(toUpdate);
+    return ResponseEntity.ok(toDto(saved));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    bookingService.delete(id);
+    return ResponseEntity.noContent().build();
+  }
+
+  private BookingDTO toDto(BookingEntity entity) {
+    BookingDTO dto = new BookingDTO();
+    dto.setId(entity.getId());
+    dto.setPropertyId(entity.getProperty().getId());
+    dto.setUserId(entity.getUser().getId());
+    dto.setStart(entity.getStart());
+    dto.setEnd(entity.getEnd());
+    dto.setStatus(entity.getStatus());
+    return dto;
+  }
+
+  private BookingEntity toEntity(BookingDTO dto) {
+    BookingEntity entity = new BookingEntity();
+    PropertyEntity prop = new PropertyEntity();
+    prop.setId(dto.getPropertyId());
+    entity.setProperty(prop);
+    UserEntity user = new UserEntity();
+    user.setId(dto.getUserId());
+    entity.setUser(user);
+    entity.setStart(dto.getStart());
+    entity.setEnd(dto.getEnd());
+    entity.setStatus(dto.getStatus());
+    return entity;
+  }
+}

--- a/services/backend/src/main/java/com/example/app/booking/BookingDTO.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingDTO.java
@@ -1,0 +1,60 @@
+package com.example.app.booking;
+
+import java.time.LocalDateTime;
+
+public class BookingDTO {
+  private Long id;
+  private Long propertyId;
+  private Long userId;
+  private LocalDateTime start;
+  private LocalDateTime end;
+  private BookingStatus status;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Long getPropertyId() {
+    return propertyId;
+  }
+
+  public void setPropertyId(Long propertyId) {
+    this.propertyId = propertyId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
+
+  public LocalDateTime getStart() {
+    return start;
+  }
+
+  public void setStart(LocalDateTime start) {
+    this.start = start;
+  }
+
+  public LocalDateTime getEnd() {
+    return end;
+  }
+
+  public void setEnd(LocalDateTime end) {
+    this.end = end;
+  }
+
+  public BookingStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(BookingStatus status) {
+    this.status = status;
+  }
+}

--- a/services/backend/src/main/java/com/example/app/booking/BookingEntity.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingEntity.java
@@ -2,6 +2,7 @@ package com.example.app.booking;
 
 import com.example.app.property.PropertyEntity;
 import com.example.app.user.UserEntity;
+import com.example.app.booking.BookingStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -11,6 +12,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
 import java.time.LocalDateTime;
 
 @Entity
@@ -34,7 +37,8 @@ public class BookingEntity {
   @Column(name = "end")
   private LocalDateTime end;
 
-  private String status;
+  @Enumerated(EnumType.STRING)
+  private BookingStatus status;
 
   public BookingEntity() {}
 
@@ -44,7 +48,7 @@ public class BookingEntity {
       UserEntity user,
       LocalDateTime start,
       LocalDateTime end,
-      String status) {
+      BookingStatus status) {
     this.id = id;
     this.property = property;
     this.user = user;
@@ -93,11 +97,11 @@ public class BookingEntity {
     this.end = end;
   }
 
-  public String getStatus() {
+  public BookingStatus getStatus() {
     return status;
   }
 
-  public void setStatus(String status) {
+  public void setStatus(BookingStatus status) {
     this.status = status;
   }
 }

--- a/services/backend/src/main/java/com/example/app/booking/BookingRepository.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingRepository.java
@@ -1,5 +1,14 @@
 package com.example.app.booking;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BookingRepository extends JpaRepository<BookingEntity, Long> {}
+public interface BookingRepository extends JpaRepository<BookingEntity, Long> {
+  List<BookingEntity> findByPropertyId(Long propertyId);
+
+  List<BookingEntity> findByUserId(Long userId);
+
+  List<BookingEntity> findByPropertyIdAndUserId(Long propertyId, Long userId);
+
+  List<BookingEntity> findByPropertyIdAndStatus(Long propertyId, BookingStatus status);
+}

--- a/services/backend/src/main/java/com/example/app/booking/BookingService.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingService.java
@@ -1,0 +1,65 @@
+package com.example.app.booking;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+import com.example.app.booking.BookingRepository;
+import com.example.app.booking.BookingEntity;
+import com.example.app.booking.BookingStatus;
+import com.example.app.booking.OverlapException;
+
+@Service
+public class BookingService {
+  private final BookingRepository bookingRepository;
+
+  public BookingService(BookingRepository bookingRepository) {
+    this.bookingRepository = bookingRepository;
+  }
+
+  public BookingEntity create(BookingEntity booking) {
+    checkOverlap(booking, null);
+    return bookingRepository.save(booking);
+  }
+
+  public BookingEntity update(BookingEntity booking) {
+    checkOverlap(booking, booking.getId());
+    return bookingRepository.save(booking);
+  }
+
+  public List<BookingEntity> findAll(Optional<Long> propertyId, Optional<Long> userId) {
+    if (propertyId.isPresent() && userId.isPresent()) {
+      return bookingRepository.findByPropertyIdAndUserId(propertyId.get(), userId.get());
+    }
+    if (propertyId.isPresent()) {
+      return bookingRepository.findByPropertyId(propertyId.get());
+    }
+    if (userId.isPresent()) {
+      return bookingRepository.findByUserId(userId.get());
+    }
+    return bookingRepository.findAll();
+  }
+
+  public BookingEntity findById(Long id) {
+    return bookingRepository.findById(id).orElse(null);
+  }
+
+  public void delete(Long id) {
+    bookingRepository.deleteById(id);
+  }
+
+  private void checkOverlap(BookingEntity booking, Long ignoreId) {
+    List<BookingEntity> existing =
+        bookingRepository.findByPropertyIdAndStatus(booking.getProperty().getId(), BookingStatus.CONFIRMED);
+    for (BookingEntity other : existing) {
+      if (ignoreId != null && other.getId().equals(ignoreId)) {
+        continue;
+      }
+      boolean overlaps =
+          booking.getStart().isBefore(other.getEnd()) && booking.getEnd().isAfter(other.getStart());
+      if (overlaps) {
+        throw new OverlapException();
+      }
+    }
+  }
+}

--- a/services/backend/src/main/java/com/example/app/booking/BookingStatus.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingStatus.java
@@ -1,0 +1,7 @@
+package com.example.app.booking;
+
+public enum BookingStatus {
+  PENDING,
+  CONFIRMED,
+  CANCELLED
+}

--- a/services/backend/src/main/java/com/example/app/booking/OverlapException.java
+++ b/services/backend/src/main/java/com/example/app/booking/OverlapException.java
@@ -1,0 +1,7 @@
+package com.example.app.booking;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class OverlapException extends RuntimeException {}

--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -144,6 +144,95 @@ paths:
       responses:
         '204':
           description: "Deleted"
+
+  /bookings:
+    post:
+      summary: "Create booking"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingDTO'
+      responses:
+        '201':
+          description: "Created"
+    get:
+      summary: "Get booking list"
+      parameters:
+        - name: propertyId
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: userId
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BookingDTO'
+
+  /bookings/{id}:
+    get:
+      summary: "Get booking"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingDTO'
+    put:
+      summary: "Update booking"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingDTO'
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingDTO'
+    delete:
+      summary: "Delete booking"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: "Deleted"
 components:
   schemas:
     FeatureDTO:
@@ -184,6 +273,32 @@ components:
         ownerId:
           type: integer
           format: int64
+    BookingDTO:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        propertyId:
+          type: integer
+          format: int64
+        userId:
+          type: integer
+          format: int64
+        start:
+          type: string
+          format: date-time
+        end:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/BookingStatus'
+    BookingStatus:
+      type: string
+      enum:
+        - PENDING
+        - CONFIRMED
+        - CANCELLED
     UserRole:
       type: string
       enum:

--- a/services/backend/src/test/java/com/example/app/booking/BookingControllerTests.java
+++ b/services/backend/src/test/java/com/example/app/booking/BookingControllerTests.java
@@ -1,0 +1,40 @@
+package com.example.app.booking;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class BookingControllerTests {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  public void testBookingCreationOverlapAndList() throws Exception {
+    String userJson = "{\"role\":\"GUEST\",\"email\":\"b@example.com\",\"passwordHash\":\"x\"}";
+    mockMvc.perform(post("/users").contentType("application/json").content(userJson))
+        .andExpect(status().isCreated());
+
+    String propertyJson = "{\"name\":\"House\",\"address\":\"Street\"}";
+    mockMvc.perform(post("/properties").contentType("application/json").content(propertyJson))
+        .andExpect(status().isCreated());
+
+    String bookingJson = "{\"propertyId\":1,\"userId\":1,\"start\":\"2024-01-01T10:00:00\",\"end\":\"2024-01-02T10:00:00\",\"status\":\"CONFIRMED\"}";
+    mockMvc.perform(post("/bookings").contentType("application/json").content(bookingJson))
+        .andExpect(status().isCreated());
+
+    mockMvc.perform(post("/bookings").contentType("application/json").content(bookingJson))
+        .andExpect(status().isConflict());
+
+    mockMvc.perform(get("/bookings").param("propertyId", "1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].propertyId").value(1));
+  }
+}


### PR DESCRIPTION
## Summary
- implement BookingController with CRUD
- add BookingService with overlap check
- create BookingDTO and BookingStatus enum
- define bookings endpoints and schema in OpenAPI
- test booking overlap rule

## Testing
- ❌ `./scripts/generate.sh` *(fails: `docker: command not found`)*
- ❌ `services/backend/mvnw -q -f services/backend/pom.xml test` *(fails: `Failed to fetch apache-maven-bin.zip`)*
- ❌ `pytest -q` *(fails: `pytest: command not found`)*