### PR TITLE
Update user retrieval order

### DIFF
--- a/services/backend/src/main/java/com/example/app/user/UserRepository.java
+++ b/services/backend/src/main/java/com/example/app/user/UserRepository.java
@@ -1,5 +1,8 @@
 package com.example.app.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
-public interface UserRepository extends JpaRepository<UserEntity, Long> {}
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
+  List<UserEntity> findAllByOrderByIdAsc();
+}

--- a/services/backend/src/main/java/com/example/app/user/UserService.java
+++ b/services/backend/src/main/java/com/example/app/user/UserService.java
@@ -17,6 +17,6 @@ public class UserService {
   }
 
   public List<UserEntity> findAll() {
-    return userRepository.findAll();
+    return userRepository.findAllByOrderByIdAsc();
   }
 }


### PR DESCRIPTION
## Summary
- keep user list ordering stable by adding `findAllByOrderByIdAsc` to UserRepository
- call the new method from `UserService.findAll`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `./mvnw test -q` in `services/backend` *(fails: could not fetch Maven)*