### PR TITLE
Fix OpenAPI comment about included endpoints

### DIFF
--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -9,7 +9,7 @@ servers:
   - url: http://localhost:8080/api
     description: Local dev
 
-# تم تضمين المسارات الجديدة فقط (/feature و /status) في الوثيقة
+# تشمل الوثيقة المسارات الحالية مثل /feature و /status و /users و /properties
 paths:
   /feature:
     get:


### PR DESCRIPTION
## Summary
- update outdated note about the endpoints in openapi.yaml

## Testing
- `./scripts/generate.sh` *(fails: docker not found)*
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `./mvnw test` in `services/backend` *(fails: network issue downloading Maven)*