### PR TITLE
Update booking fields and OpenAPI comment

### DIFF
--- a/services/backend/src/main/java/com/example/app/booking/BookingEntity.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingEntity.java
@@ -29,10 +29,11 @@ public class BookingEntity {
   @JoinColumn(name = "user_id")
   private UserEntity user;
 
-  private LocalDateTime start;
+  @Column(name = "start")
+  private LocalDateTime startAt;
 
   @Column(name = "end")
-  private LocalDateTime end;
+  private LocalDateTime endAt;
 
   private String status;
 
@@ -42,14 +43,14 @@ public class BookingEntity {
       Long id,
       PropertyEntity property,
       UserEntity user,
-      LocalDateTime start,
-      LocalDateTime end,
+      LocalDateTime startAt,
+      LocalDateTime endAt,
       String status) {
     this.id = id;
     this.property = property;
     this.user = user;
-    this.start = start;
-    this.end = end;
+    this.startAt = startAt;
+    this.endAt = endAt;
     this.status = status;
   }
 
@@ -77,20 +78,20 @@ public class BookingEntity {
     this.user = user;
   }
 
-  public LocalDateTime getStart() {
-    return start;
+  public LocalDateTime getStartAt() {
+    return startAt;
   }
 
-  public void setStart(LocalDateTime start) {
-    this.start = start;
+  public void setStartAt(LocalDateTime startAt) {
+    this.startAt = startAt;
   }
 
-  public LocalDateTime getEnd() {
-    return end;
+  public LocalDateTime getEndAt() {
+    return endAt;
   }
 
-  public void setEnd(LocalDateTime end) {
-    this.end = end;
+  public void setEndAt(LocalDateTime endAt) {
+    this.endAt = endAt;
   }
 
   public String getStatus() {

--- a/services/backend/src/main/java/com/example/app/booking/BookingRepository.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingRepository.java
@@ -12,11 +12,11 @@ public interface BookingRepository extends JpaRepository<BookingEntity, Long> {
       "SELECT b FROM BookingEntity b "
           + "WHERE b.property.id = :propertyId "
           + "AND (:excludeId IS NULL OR b.id <> :excludeId) "
-          + "AND b.start < :end "
-          + "AND b.end > :start")
+          + "AND b.startAt < :endAt "
+          + "AND b.endAt > :startAt")
   List<BookingEntity> findOverlapping(
       @Param("propertyId") Long propertyId,
-      @Param("start") LocalDateTime start,
-      @Param("end") LocalDateTime end,
+      @Param("startAt") LocalDateTime startAt,
+      @Param("endAt") LocalDateTime endAt,
       @Param("excludeId") Long excludeId);
 }

--- a/services/backend/src/main/java/com/example/app/booking/BookingService.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingService.java
@@ -25,8 +25,8 @@ public class BookingService {
     return entity.orElse(null);
   }
 
-  public List<BookingEntity> findOverlapping(Long propertyId, LocalDateTime start, LocalDateTime end, Long excludeId) {
-    return bookingRepository.findOverlapping(propertyId, start, end, excludeId);
+  public List<BookingEntity> findOverlapping(Long propertyId, LocalDateTime startAt, LocalDateTime endAt, Long excludeId) {
+    return bookingRepository.findOverlapping(propertyId, startAt, endAt, excludeId);
   }
 
   public BookingEntity update(BookingEntity booking) {
@@ -38,14 +38,14 @@ public class BookingService {
       return null;
     }
     BookingEntity existing = existingOpt.get();
-    boolean startChanged = booking.getStart() != null && !booking.getStart().equals(existing.getStart());
-    boolean endChanged = booking.getEnd() != null && !booking.getEnd().equals(existing.getEnd());
+    boolean startChanged = booking.getStartAt() != null && !booking.getStartAt().equals(existing.getStartAt());
+    boolean endChanged = booking.getEndAt() != null && !booking.getEndAt().equals(existing.getEndAt());
     Long existingPropId = existing.getProperty() != null ? existing.getProperty().getId() : null;
     Long newPropId = booking.getProperty() != null ? booking.getProperty().getId() : null;
     boolean propertyChanged = (existingPropId != null ? !existingPropId.equals(newPropId) : newPropId != null);
 
     if (startChanged || endChanged || propertyChanged) {
-      List<BookingEntity> overlaps = findOverlapping(newPropId, booking.getStart(), booking.getEnd(), booking.getId());
+      List<BookingEntity> overlaps = findOverlapping(newPropId, booking.getStartAt(), booking.getEndAt(), booking.getId());
       if (!overlaps.isEmpty()) {
         throw new ResponseStatusException(HttpStatus.CONFLICT, "Booking overlaps");
       }
@@ -53,8 +53,8 @@ public class BookingService {
 
     existing.setProperty(booking.getProperty());
     existing.setUser(booking.getUser());
-    existing.setStart(booking.getStart());
-    existing.setEnd(booking.getEnd());
+    existing.setStartAt(booking.getStartAt());
+    existing.setEndAt(booking.getEndAt());
     existing.setStatus(booking.getStatus());
 
     return bookingRepository.save(existing);

--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -9,7 +9,6 @@ servers:
   - url: http://localhost:8080/api
     description: Local dev
 
-# تشمل الوثيقة المسارات الحالية مثل /feature و /status و /users و /properties
 paths:
   /feature:
     get:
@@ -173,8 +172,7 @@ components:
         - passwordHash
     PropertyDTO:
       type: object
-      required:
-        - ownerId
+      required: [ownerId]
       properties:
         id:
           type: integer


### PR DESCRIPTION
## Summary
- remove Arabic OpenAPI comment
- mark `ownerId` as required inline in OpenAPI spec
- rename booking fields to `startAt` and `endAt`
- adjust repository and service to use new field names

## Testing
- `./scripts/generate.sh` *(fails: docker not found)*
- `pytest -q` *(fails: command not found)*
- `./mvnw test -q` in `services/backend` *(fails: failed to fetch maven)*