### PR TITLE
Add booking status enum

### DIFF
--- a/services/backend/src/main/java/com/example/app/booking/BookingEntity.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingEntity.java
@@ -11,6 +11,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import com.example.app.booking.BookingStatus;
 import java.time.LocalDateTime;
 
 @Entity
@@ -35,7 +38,8 @@ public class BookingEntity {
   @Column(name = "end_at")
   private LocalDateTime endAt;
 
-  private String status;
+  @Enumerated(EnumType.STRING)
+  private BookingStatus status;
 
   public BookingEntity() {}
 
@@ -45,7 +49,7 @@ public class BookingEntity {
       UserEntity user,
       LocalDateTime startAt,
       LocalDateTime endAt,
-      String status) {
+      BookingStatus status) {
     this.id = id;
     this.property = property;
     this.user = user;
@@ -94,11 +98,11 @@ public class BookingEntity {
     this.endAt = endAt;
   }
 
-  public String getStatus() {
+  public BookingStatus getStatus() {
     return status;
   }
 
-  public void setStatus(String status) {
+  public void setStatus(BookingStatus status) {
     this.status = status;
   }
 }

--- a/services/backend/src/main/java/com/example/app/booking/BookingStatus.java
+++ b/services/backend/src/main/java/com/example/app/booking/BookingStatus.java
@@ -1,0 +1,7 @@
+package com.example.app.booking;
+
+public enum BookingStatus {
+    PENDING,
+    CONFIRMED,
+    CANCELLED
+}

--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -144,6 +144,91 @@ paths:
       responses:
         '204':
           description: "Deleted"
+  /bookings:
+    post:
+      summary: "Create booking"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingDTO'
+      responses:
+        '201':
+          description: "Created"
+    get:
+      summary: "Get booking list"
+      parameters:
+        - in: query
+          name: propertyId
+          schema:
+            type: integer
+            format: int64
+        - in: query
+          name: userId
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BookingDTO'
+  /bookings/{id}:
+    get:
+      summary: "Get booking"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingDTO'
+    put:
+      summary: "Update booking"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookingDTO'
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookingDTO'
+    delete:
+      summary: "Delete booking"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: "Deleted"
 components:
   schemas:
     FeatureDTO:
@@ -188,6 +273,38 @@ components:
           format: int64
         active:
           type: boolean
+    BookingDTO:
+      type: object
+      required:
+        - propertyId
+        - userId
+        - startAt
+        - endAt
+        - status
+      properties:
+        id:
+          type: integer
+          format: int64
+        propertyId:
+          type: integer
+          format: int64
+        userId:
+          type: integer
+          format: int64
+        startAt:
+          type: string
+          format: date-time
+        endAt:
+          type: string
+          format: date-time
+        status:
+          $ref: '#/components/schemas/BookingStatus'
+    BookingStatus:
+      type: string
+      enum:
+        - PENDING
+        - CONFIRMED
+        - CANCELLED
     UserRole:
       type: string
       enum:

--- a/services/backend/src/test/java/com/example/app/booking/BookingServiceTests.java
+++ b/services/backend/src/test/java/com/example/app/booking/BookingServiceTests.java
@@ -8,6 +8,7 @@ import com.example.app.property.PropertyRepository;
 import com.example.app.user.UserEntity;
 import com.example.app.user.UserRepository;
 import com.example.app.user.UserRole;
+import com.example.app.booking.BookingStatus;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +37,7 @@ public class BookingServiceTests {
     first.setUser(user);
     first.setStartAt(LocalDateTime.of(2024, 1, 1, 10, 0));
     first.setEndAt(LocalDateTime.of(2024, 1, 1, 12, 0));
-    first.setStatus("NEW");
+    first.setStatus(BookingStatus.PENDING);
     bookingService.create(first);
 
     BookingEntity overlap = new BookingEntity();
@@ -44,7 +45,7 @@ public class BookingServiceTests {
     overlap.setUser(user);
     overlap.setStartAt(LocalDateTime.of(2024, 1, 1, 11, 0));
     overlap.setEndAt(LocalDateTime.of(2024, 1, 1, 13, 0));
-    overlap.setStatus("NEW");
+    overlap.setStatus(BookingStatus.PENDING);
 
     ResponseStatusException ex =
         assertThrows(ResponseStatusException.class, () -> bookingService.create(overlap));


### PR DESCRIPTION
## Summary
- fix OpenAPI indentation and required fields
- add BookingStatus enum and update BookingEntity
- document optional filters for booking list

## Testing
- `./scripts/generate.sh` *(fails: docker not found)*
- `pytest -q` *(fails: command not found)*
- `./mvnw test` *(fails: network access failed)*
- `flutter test` *(fails: command not found)*