### PR TITLE
Update OpenAPI booking tags

### DIFF
--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -146,6 +146,7 @@ paths:
           description: "Deleted"
   /bookings:
     post:
+      tags: [Booking]
       summary: "Create booking"
       requestBody:
         required: true
@@ -157,6 +158,7 @@ paths:
         '201':
           description: "Created"
     get:
+      tags: [Booking]
       summary: "Get booking list"
       parameters:
         - in: query
@@ -180,6 +182,7 @@ paths:
                   $ref: '#/components/schemas/BookingDTO'
   /bookings/{id}:
     get:
+      tags: [Booking]
       summary: "Get booking"
       parameters:
         - name: id
@@ -196,6 +199,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/BookingDTO'
     put:
+      tags: [Booking]
       summary: "Update booking"
       parameters:
         - name: id
@@ -218,6 +222,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/BookingDTO'
     delete:
+      tags: [Booking]
       summary: "Delete booking"
       parameters:
         - name: id


### PR DESCRIPTION
## Summary
- annotate Booking endpoints in openapi.yaml with `tags: [Booking]`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `./mvnw test` in `services/backend` *(fails: could not download Maven)*
- `./scripts/generate.sh` *(fails: docker not found)*