### PR TITLE
Add TaskController stubs for unimplemented endpoints

### DIFF
--- a/services/backend/src/gen/.openapi-generator/FILES
+++ b/services/backend/src/gen/.openapi-generator/FILES
@@ -7,3 +7,6 @@ src/gen/org/openapitools/model/FeatureDTO.java
 src/gen/com/example/app/api/BookingApi.java
 src/gen/com/example/app/model/BookingDTO.java
 src/gen/com/example/app/model/BookingStatus.java
+src/gen/com/example/app/api/TaskApi.java
+src/gen/com/example/app/model/TaskDTO.java
+src/gen/com/example/app/model/TaskStatus.java

--- a/services/backend/src/gen/src/gen/com/example/app/api/TaskApi.java
+++ b/services/backend/src/gen/src/gen/com/example/app/api/TaskApi.java
@@ -1,0 +1,34 @@
+package com.example.app.api;
+
+import com.example.app.model.TaskDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+import java.util.List;
+
+@Tag(name = "Task")
+public interface TaskApi {
+
+    @Operation(operationId = "tasksPost", summary = "Create task", responses = {
+            @ApiResponse(responseCode = "201", description = "Created")
+    })
+    @RequestMapping(method = RequestMethod.POST, value = "/tasks", consumes = {"application/json"})
+    ResponseEntity<Void> tasksPost(@Parameter(name = "TaskDTO", required = true) @Valid @RequestBody TaskDTO taskDTO);
+
+    @Operation(operationId = "tasksGet", summary = "Get task list", responses = {
+            @ApiResponse(responseCode = "200", description = "Success", content = {
+                    @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = TaskDTO.class)))
+            })
+    })
+    @RequestMapping(method = RequestMethod.GET, value = "/tasks", produces = {"application/json"})
+    ResponseEntity<List<TaskDTO>> tasksGet(
+            @Parameter(name = "bookingId") @RequestParam(value = "bookingId", required = false) Long bookingId,
+            @Parameter(name = "cleanerId") @RequestParam(value = "cleanerId", required = false) Long cleanerId);
+}

--- a/services/backend/src/gen/src/gen/com/example/app/model/TaskDTO.java
+++ b/services/backend/src/gen/src/gen/com/example/app/model/TaskDTO.java
@@ -1,0 +1,62 @@
+package com.example.app.model;
+
+import jakarta.annotation.Generated;
+import java.time.OffsetDateTime;
+
+@Generated(value = "manual")
+public class TaskDTO {
+  private Long id;
+  private Long bookingId;
+  private Long cleanerId;
+  private String type;
+  private TaskStatus status;
+  private OffsetDateTime due;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Long getBookingId() {
+    return bookingId;
+  }
+
+  public void setBookingId(Long bookingId) {
+    this.bookingId = bookingId;
+  }
+
+  public Long getCleanerId() {
+    return cleanerId;
+  }
+
+  public void setCleanerId(Long cleanerId) {
+    this.cleanerId = cleanerId;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public TaskStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(TaskStatus status) {
+    this.status = status;
+  }
+
+  public OffsetDateTime getDue() {
+    return due;
+  }
+
+  public void setDue(OffsetDateTime due) {
+    this.due = due;
+  }
+}

--- a/services/backend/src/gen/src/gen/com/example/app/model/TaskStatus.java
+++ b/services/backend/src/gen/src/gen/com/example/app/model/TaskStatus.java
@@ -1,0 +1,9 @@
+package com.example.app.model;
+
+import jakarta.annotation.Generated;
+
+@Generated(value = "manual")
+public enum TaskStatus {
+    PENDING,
+    DONE
+}

--- a/services/backend/src/main/java/com/example/app/task/TaskController.java
+++ b/services/backend/src/main/java/com/example/app/task/TaskController.java
@@ -1,0 +1,81 @@
+package com.example.app.task;
+
+import com.example.app.api.TaskApi;
+import com.example.app.booking.BookingEntity;
+import com.example.app.booking.BookingService;
+import com.example.app.model.TaskDTO;
+import com.example.app.user.UserEntity;
+import com.example.app.user.UserRepository;
+import jakarta.validation.Valid;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class TaskController implements TaskApi {
+    private final TaskService taskService;
+    private final BookingService bookingService;
+    private final UserRepository userRepository;
+
+    @Override
+    public ResponseEntity<Void> tasksPost(@Valid @RequestBody TaskDTO dto) {
+        BookingEntity booking = bookingService.findById(dto.getBookingId());
+        if (booking == null) throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Booking not found");
+
+        UserEntity cleaner = userRepository.findById(dto.getCleanerId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Cleaner not found"));
+
+        TaskEntity entity = new TaskEntity(
+                null,
+                booking,
+                cleaner,
+                dto.getType(),
+                TaskStatus.PENDING,
+                dto.getDue().toLocalDateTime()
+        );
+        taskService.create(entity);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Override
+    public ResponseEntity<List<TaskDTO>> tasksGet(Long bookingId, Long cleanerId) {
+        List<TaskDTO> list = taskService.findAll().stream()
+            .filter(t -> bookingId == null || t.getBooking().getId().equals(bookingId))
+            .filter(t -> cleanerId == null || t.getCleaner().getId().equals(cleanerId))
+            .map(this::toDto)
+            .toList();
+        return ResponseEntity.ok(list);
+    }
+
+    @Override
+    public ResponseEntity<TaskDTO> tasksIdPut(Long id, @Valid @RequestBody TaskDTO dto) {
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+    }
+
+    @Override
+    public ResponseEntity<TaskDTO> tasksIdGet(Long id) {
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+    }
+
+    @Override
+    public ResponseEntity<Void> tasksIdDelete(Long id) {
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+    }
+
+    private TaskDTO toDto(TaskEntity e) {
+        TaskDTO d = new TaskDTO();
+        d.setId(e.getId());
+        d.setBookingId(e.getBooking().getId());
+        d.setCleanerId(e.getCleaner().getId());
+        d.setType(e.getType());
+        d.setStatus(com.example.app.model.TaskStatus.valueOf(e.getStatus().name()));
+        d.setDue(e.getDue().atOffset(OffsetDateTime.now().getOffset()));
+        return d;
+    }
+}


### PR DESCRIPTION
## Summary
- implement placeholder endpoints tasksIdPut, tasksIdGet and tasksIdDelete so TaskController satisfies TaskApi

## Testing
- `pytest -q` *(fails: command not found)*
- `./mvnw test -q` *(fails to fetch Maven wrapper)*