### PR TITLE
fix(migration): add alter script for messages

### DIFF
--- a/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
+++ b/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
@@ -1,8 +1,18 @@
+
+/* إعادة تسمية الأعمدة الموجودة */
 ALTER TABLE messages RENAME COLUMN from_id TO sender_id;
-ALTER TABLE messages RENAME CONSTRAINT fk_message_from TO fk_message_sender;
-ALTER TABLE messages DROP COLUMN to_id;
-ALTER TABLE messages RENAME COLUMN body TO content;
+ALTER TABLE messages RENAME COLUMN body     TO content;
 ALTER TABLE messages ALTER COLUMN content TYPE TEXT;
-ALTER TABLE messages RENAME COLUMN ts TO sent_at;
+ALTER TABLE messages RENAME COLUMN ts       TO sent_at;
+
+/* إعادة تسمية الـ FK الحالي على sender_id */
+ALTER TABLE messages RENAME CONSTRAINT fk_message_from TO fk_message_sender;
+
+/* حذف FK الذى يرتبط بالعمود to_id ثم حذف العمود */
+ALTER TABLE messages DROP CONSTRAINT fk_message_to;
+ALTER TABLE messages DROP COLUMN to_id;
+
+/* إضافة booking_id وربطه بالحجوزات */
 ALTER TABLE messages ADD COLUMN booking_id BIGINT NOT NULL;
-ALTER TABLE messages ADD CONSTRAINT fk_message_booking FOREIGN KEY (booking_id) REFERENCES bookings(id);
+ALTER TABLE messages ADD CONSTRAINT fk_message_booking
+  FOREIGN KEY (booking_id) REFERENCES bookings(id);

--- a/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
+++ b/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
@@ -1,0 +1,8 @@
+ALTER TABLE messages RENAME COLUMN from_id TO sender_id;
+ALTER TABLE messages RENAME CONSTRAINT fk_message_from TO fk_message_sender;
+ALTER TABLE messages DROP COLUMN to_id;
+ALTER TABLE messages RENAME COLUMN body TO content;
+ALTER TABLE messages ALTER COLUMN content TYPE TEXT;
+ALTER TABLE messages RENAME COLUMN ts TO sent_at;
+ALTER TABLE messages ADD COLUMN booking_id BIGINT NOT NULL;
+ALTER TABLE messages ADD CONSTRAINT fk_message_booking FOREIGN KEY (booking_id) REFERENCES bookings(id);

--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -328,6 +328,39 @@ paths:
       responses:
         '204':
           description: "Deleted"
+
+  /messages:
+    post:
+      tags: [Message]
+      summary: "Create message"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageDTO'
+      responses:
+        '201':
+          description: "Created"
+    get:
+      tags: [Message]
+      summary: "Get message list"
+      parameters:
+        - in: query
+          name: bookingId
+          required: false
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MessageDTO'
 components:
   schemas:
     FeatureDTO:
@@ -429,14 +462,36 @@ components:
         due:
           type: string
           format: date-time
-    TaskStatus:
-      type: string
-      enum:
-        - PENDING
-        - DONE
-    UserRole:
-      type: string
-      enum:
-        - GUEST
-        - ADMIN
-        - CLEANER
+      TaskStatus:
+        type: string
+        enum:
+          - PENDING
+          - DONE
+      MessageDTO:
+        type: object
+        required:
+          - bookingId
+          - senderId
+          - content
+          - sentAt
+        properties:
+          id:
+            type: integer
+            format: int64
+          bookingId:
+            type: integer
+            format: int64
+          senderId:
+            type: integer
+            format: int64
+          content:
+            type: string
+          sentAt:
+            type: string
+            format: date-time
+      UserRole:
+        type: string
+        enum:
+          - GUEST
+          - ADMIN
+          - CLEANER


### PR DESCRIPTION
## Summary
- keep V5 message migration immutable
- add V9 migration to alter message columns for booking/sender/content/sentAt

## Testing
- `./scripts/generate.sh` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*
- `./mvnw test` *(fails: could not download Maven)*