### PR TITLE
feat(message): add endpoints and migration

### DIFF
--- a/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
+++ b/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
@@ -1,0 +1,14 @@
+ALTER TABLE messages
+    RENAME COLUMN from_id TO sender_id;
+ALTER TABLE messages
+    RENAME COLUMN body TO content;
+ALTER TABLE messages
+    RENAME COLUMN ts TO sent_at;
+ALTER TABLE messages
+    DROP CONSTRAINT fk_message_to,
+    DROP COLUMN to_id;
+ALTER TABLE messages
+    ADD COLUMN booking_id BIGINT NOT NULL;
+ALTER TABLE messages
+    ADD CONSTRAINT fk_message_booking FOREIGN KEY (booking_id) REFERENCES bookings(id),
+    ADD CONSTRAINT fk_message_sender FOREIGN KEY (sender_id) REFERENCES users(id);

--- a/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
+++ b/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
@@ -1,14 +1,18 @@
-ALTER TABLE messages
-    RENAME COLUMN from_id TO sender_id;
-ALTER TABLE messages
-    RENAME COLUMN body TO content;
-ALTER TABLE messages
-    RENAME COLUMN ts TO sent_at;
-ALTER TABLE messages
-    DROP CONSTRAINT fk_message_to,
-    DROP COLUMN to_id;
-ALTER TABLE messages
-    ADD COLUMN booking_id BIGINT NOT NULL;
-ALTER TABLE messages
-    ADD CONSTRAINT fk_message_booking FOREIGN KEY (booking_id) REFERENCES bookings(id),
-    ADD CONSTRAINT fk_message_sender FOREIGN KEY (sender_id) REFERENCES users(id);
+
+/* إعادة تسمية الأعمدة الموجودة */
+ALTER TABLE messages RENAME COLUMN from_id TO sender_id;
+ALTER TABLE messages RENAME COLUMN body     TO content;
+ALTER TABLE messages ALTER COLUMN content TYPE TEXT;
+ALTER TABLE messages RENAME COLUMN ts       TO sent_at;
+
+/* إعادة تسمية الـ FK الحالي على sender_id */
+ALTER TABLE messages RENAME CONSTRAINT fk_message_from TO fk_message_sender;
+
+/* حذف FK الذى يرتبط بالعمود to_id ثم حذف العمود */
+ALTER TABLE messages DROP CONSTRAINT fk_message_to;
+ALTER TABLE messages DROP COLUMN to_id;
+
+/* إضافة booking_id وربطه بالحجوزات */
+ALTER TABLE messages ADD COLUMN booking_id BIGINT NOT NULL;
+ALTER TABLE messages ADD CONSTRAINT fk_message_booking
+  FOREIGN KEY (booking_id) REFERENCES bookings(id);

--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -328,6 +328,39 @@ paths:
       responses:
         '204':
           description: "Deleted"
+
+  /messages:
+    post:
+      tags: [Message]
+      summary: "Create message"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageDTO'
+      responses:
+        '201':
+          description: "Created"
+    get:
+      tags: [Message]
+      summary: "Get message list"
+      parameters:
+        - in: query
+          name: bookingId
+          required: false
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MessageDTO'
 components:
   schemas:
     FeatureDTO:
@@ -434,6 +467,28 @@ components:
       enum:
         - PENDING
         - DONE
+    MessageDTO:
+      type: object
+      required:
+        - bookingId
+        - senderId
+        - content
+        - sentAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        bookingId:
+          type: integer
+          format: int64
+        senderId:
+          type: integer
+          format: int64
+        content:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
     UserRole:
       type: string
       enum:


### PR DESCRIPTION
## Summary
- add `/messages` endpoints with MessageDTO schema
- fix YAML indentation for TaskStatus and UserRole
- restore initial V5 migration and add V9 for altering messages table

## Testing
- `./scripts/generate.sh` *(fails: docker not found)*
- `pytest -q` *(fails: command not found)*
- `./mvnw test -q` *(fails: failed to fetch Maven)*