### PR TITLE
feat(message): implement entity and repo

### DIFF
--- a/services/backend/src/main/java/com/example/app/message/MessageEntity.java
+++ b/services/backend/src/main/java/com/example/app/message/MessageEntity.java
@@ -1,14 +1,8 @@
 package com.example.app.message;
 
+import com.example.app.booking.BookingEntity;
 import com.example.app.user.UserEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
@@ -20,24 +14,32 @@ public class MessageEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "from_id")
-  private UserEntity from;
+  @JoinColumn(name = "booking_id", nullable = false)
+  private BookingEntity booking;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "to_id")
-  private UserEntity to;
+  @JoinColumn(name = "sender_id", nullable = false)
+  private UserEntity sender;
 
-  private String body;
-  private LocalDateTime ts;
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Column(name = "sent_at", nullable = false)
+  private LocalDateTime sentAt;
 
   public MessageEntity() {}
 
-  public MessageEntity(Long id, UserEntity from, UserEntity to, String body, LocalDateTime ts) {
+  public MessageEntity(
+      Long id,
+      BookingEntity booking,
+      UserEntity sender,
+      String content,
+      LocalDateTime sentAt) {
     this.id = id;
-    this.from = from;
-    this.to = to;
-    this.body = body;
-    this.ts = ts;
+    this.booking = booking;
+    this.sender = sender;
+    this.content = content;
+    this.sentAt = sentAt;
   }
 
   public Long getId() {
@@ -48,35 +50,35 @@ public class MessageEntity {
     this.id = id;
   }
 
-  public UserEntity getFrom() {
-    return from;
+  public BookingEntity getBooking() {
+    return booking;
   }
 
-  public void setFrom(UserEntity from) {
-    this.from = from;
+  public void setBooking(BookingEntity booking) {
+    this.booking = booking;
   }
 
-  public UserEntity getTo() {
-    return to;
+  public UserEntity getSender() {
+    return sender;
   }
 
-  public void setTo(UserEntity to) {
-    this.to = to;
+  public void setSender(UserEntity sender) {
+    this.sender = sender;
   }
 
-  public String getBody() {
-    return body;
+  public String getContent() {
+    return content;
   }
 
-  public void setBody(String body) {
-    this.body = body;
+  public void setContent(String content) {
+    this.content = content;
   }
 
-  public LocalDateTime getTs() {
-    return ts;
+  public LocalDateTime getSentAt() {
+    return sentAt;
   }
 
-  public void setTs(LocalDateTime ts) {
-    this.ts = ts;
+  public void setSentAt(LocalDateTime sentAt) {
+    this.sentAt = sentAt;
   }
 }

--- a/services/backend/src/main/java/com/example/app/message/MessageRepository.java
+++ b/services/backend/src/main/java/com/example/app/message/MessageRepository.java
@@ -1,5 +1,9 @@
 package com.example.app.message;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MessageRepository extends JpaRepository<MessageEntity, Long> {}
+public interface MessageRepository extends JpaRepository<MessageEntity, Long> {
+
+  List<MessageEntity> findByBookingIdOrderBySentAtAsc(Long bookingId);
+}

--- a/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
+++ b/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
@@ -1,0 +1,10 @@
+-- Modify messages table: rename columns and add booking_id
+ALTER TABLE messages DROP CONSTRAINT fk_message_from;
+ALTER TABLE messages DROP CONSTRAINT fk_message_to;
+ALTER TABLE messages RENAME COLUMN from_id TO sender_id;
+ALTER TABLE messages RENAME COLUMN body TO content;
+ALTER TABLE messages RENAME COLUMN ts TO sent_at;
+ALTER TABLE messages DROP COLUMN to_id;
+ALTER TABLE messages ADD COLUMN booking_id BIGINT NOT NULL;
+ALTER TABLE messages ADD CONSTRAINT fk_message_booking FOREIGN KEY (booking_id) REFERENCES bookings(id);
+ALTER TABLE messages ADD CONSTRAINT fk_message_sender FOREIGN KEY (sender_id) REFERENCES users(id);

--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -328,6 +328,39 @@ paths:
       responses:
         '204':
           description: "Deleted"
+
+  /messages:
+    post:
+      tags: [Message]
+      summary: "Create message"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageDTO'
+      responses:
+        '201':
+          description: "Created"
+    get:
+      tags: [Message]
+      summary: "Get message list"
+      parameters:
+        - in: query
+          name: bookingId
+          required: false
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MessageDTO'
 components:
   schemas:
     FeatureDTO:
@@ -434,6 +467,28 @@ components:
       enum:
         - PENDING
         - DONE
+    MessageDTO:
+      type: object
+      required:
+        - bookingId
+        - senderId
+        - content
+        - sentAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        bookingId:
+          type: integer
+          format: int64
+        senderId:
+          type: integer
+          format: int64
+        content:
+          type: string
+        sentAt:
+          type: string
+          format: date-time
     UserRole:
       type: string
       enum:


### PR DESCRIPTION
## Summary
- fix OpenAPI schema indentation and add MessageDTO
- restore original V5 migration and add V9 migration for new columns
- implement MessageEntity with booking, sender and timestamps
- expose MessageRepository method to list messages by booking

## Testing
- `docker run --rm -v $(pwd):/local openapitools/openapi-generator-cli:v6.6.0 validate -i /local/services/backend/src/main/resources/openapi.yaml` *(fails: command not found)*
- `./scripts/generate.sh` *(fails: docker not found)*
- `pytest -q` *(fails: command not found)*
- `./mvnw test -q` *(fails: could not download Maven)*