### PR TITLE
feat(message): entity, repo & service layer (B-5-T3)

### DIFF
--- a/services/backend/src/main/java/com/example/app/message/MessageEntity.java
+++ b/services/backend/src/main/java/com/example/app/message/MessageEntity.java
@@ -1,14 +1,8 @@
 package com.example.app.message;
 
+import com.example.app.booking.BookingEntity;
 import com.example.app.user.UserEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
@@ -19,25 +13,35 @@ public class MessageEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  /* FK → BOOKINGS(id)  */
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "from_id")
-  private UserEntity from;
+  @JoinColumn(name = "booking_id", nullable = false)
+  private BookingEntity booking;
 
+  /* FK → USERS(id) (sender) */
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "to_id")
-  private UserEntity to;
+  @JoinColumn(name = "sender_id", nullable = false)
+  private UserEntity sender;
 
-  private String body;
-  private LocalDateTime ts;
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Column(name = "sent_at", nullable = false)
+  private LocalDateTime sentAt;
 
   public MessageEntity() {}
 
-  public MessageEntity(Long id, UserEntity from, UserEntity to, String body, LocalDateTime ts) {
+  public MessageEntity(
+      Long id,
+      BookingEntity booking,
+      UserEntity sender,
+      String content,
+      LocalDateTime sentAt) {
     this.id = id;
-    this.from = from;
-    this.to = to;
-    this.body = body;
-    this.ts = ts;
+    this.booking = booking;
+    this.sender = sender;
+    this.content = content;
+    this.sentAt = sentAt;
   }
 
   public Long getId() {
@@ -48,35 +52,35 @@ public class MessageEntity {
     this.id = id;
   }
 
-  public UserEntity getFrom() {
-    return from;
+  public BookingEntity getBooking() {
+    return booking;
   }
 
-  public void setFrom(UserEntity from) {
-    this.from = from;
+  public void setBooking(BookingEntity booking) {
+    this.booking = booking;
   }
 
-  public UserEntity getTo() {
-    return to;
+  public UserEntity getSender() {
+    return sender;
   }
 
-  public void setTo(UserEntity to) {
-    this.to = to;
+  public void setSender(UserEntity sender) {
+    this.sender = sender;
   }
 
-  public String getBody() {
-    return body;
+  public String getContent() {
+    return content;
   }
 
-  public void setBody(String body) {
-    this.body = body;
+  public void setContent(String content) {
+    this.content = content;
   }
 
-  public LocalDateTime getTs() {
-    return ts;
+  public LocalDateTime getSentAt() {
+    return sentAt;
   }
 
-  public void setTs(LocalDateTime ts) {
-    this.ts = ts;
+  public void setSentAt(LocalDateTime sentAt) {
+    this.sentAt = sentAt;
   }
 }

--- a/services/backend/src/main/java/com/example/app/message/MessageRepository.java
+++ b/services/backend/src/main/java/com/example/app/message/MessageRepository.java
@@ -1,5 +1,9 @@
 package com.example.app.message;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MessageRepository extends JpaRepository<MessageEntity, Long> {}
+public interface MessageRepository extends JpaRepository<MessageEntity, Long> {
+
+  List<MessageEntity> findByBookingIdOrderBySentAtAsc(Long bookingId);
+}

--- a/services/backend/src/main/java/com/example/app/message/MessageService.java
+++ b/services/backend/src/main/java/com/example/app/message/MessageService.java
@@ -1,0 +1,23 @@
+package com.example.app.message;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+  private final MessageRepository messageRepository;
+
+  public MessageEntity create(MessageEntity entity) {
+    return messageRepository.save(entity);
+  }
+
+  public List<MessageEntity> list(Long bookingId) {
+    if (bookingId == null) {
+      return messageRepository.findAll();
+    }
+    return messageRepository.findByBookingIdOrderBySentAtAsc(bookingId);
+  }
+}

--- a/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
+++ b/services/backend/src/main/resources/db/migration/V9__alter_messages_table.sql
@@ -1,0 +1,9 @@
+ALTER TABLE messages DROP CONSTRAINT fk_message_from;
+ALTER TABLE messages DROP CONSTRAINT fk_message_to;
+ALTER TABLE messages RENAME COLUMN from_id TO sender_id;
+ALTER TABLE messages RENAME COLUMN to_id TO booking_id;
+ALTER TABLE messages RENAME COLUMN body TO content;
+ALTER TABLE messages RENAME COLUMN ts TO sent_at;
+ALTER TABLE messages ALTER COLUMN content TYPE TEXT;
+ALTER TABLE messages ADD CONSTRAINT fk_message_sender FOREIGN KEY (sender_id) REFERENCES users(id);
+ALTER TABLE messages ADD CONSTRAINT fk_message_booking FOREIGN KEY (booking_id) REFERENCES bookings(id);

--- a/services/backend/src/main/resources/openapi.yaml
+++ b/services/backend/src/main/resources/openapi.yaml
@@ -328,6 +328,39 @@ paths:
       responses:
         '204':
           description: "Deleted"
+
+  /messages:
+    post:
+      tags: [Message]
+      summary: "Create message"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MessageDTO'
+      responses:
+        '201':
+          description: "Created"
+    get:
+      tags: [Message]
+      summary: "Get message list"
+      parameters:
+        - in: query
+          name: bookingId
+          required: false
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: "Success"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MessageDTO'
 components:
   schemas:
     FeatureDTO:
@@ -430,13 +463,35 @@ components:
           type: string
           format: date-time
     TaskStatus:
-      type: string
-      enum:
-        - PENDING
-        - DONE
+        type: string
+        enum:
+          - PENDING
+          - DONE
+    MessageDTO:
+        type: object
+        required:
+          - bookingId
+          - senderId
+          - content
+          - sentAt
+        properties:
+          id:
+            type: integer
+            format: int64
+          bookingId:
+            type: integer
+            format: int64
+          senderId:
+            type: integer
+            format: int64
+          content:
+            type: string
+          sentAt:
+            type: string
+            format: date-time
     UserRole:
-      type: string
-      enum:
-        - GUEST
-        - ADMIN
-        - CLEANER
+        type: string
+        enum:
+          - GUEST
+          - ADMIN
+          - CLEANER

--- a/services/backend/src/test/java/com/example/app/message/MessageServiceTest.java
+++ b/services/backend/src/test/java/com/example/app/message/MessageServiceTest.java
@@ -4,8 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.app.booking.BookingEntity;
 import com.example.app.booking.BookingRepository;
+import com.example.app.booking.BookingStatus;
+import com.example.app.property.PropertyEntity;
+import com.example.app.property.PropertyRepository;
 import com.example.app.user.UserEntity;
 import com.example.app.user.UserRepository;
+import com.example.app.user.UserRole;          // ⬅️  الاستيراد الناقص
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,15 +20,30 @@ class MessageServiceTest {
 
   @Autowired MessageRepository messageRepo;
   @Autowired BookingRepository bookingRepo;
+  @Autowired PropertyRepository propertyRepo;
   @Autowired UserRepository userRepo;
 
   @Test
   void create_and_list_by_booking() {
+    // 1️⃣ مستخدم ضيف صالح
     UserEntity guest =
         userRepo.save(new UserEntity(null, UserRole.GUEST, "g@example.com", "x"));
-    BookingEntity booking =
-        bookingRepo.save(new BookingEntity(null, null, guest, LocalDateTime.now(), LocalDateTime.now(), null));
 
+    // 2️⃣ مالك + عقار + حجز
+    UserEntity owner =
+        userRepo.save(new UserEntity(null, UserRole.ADMIN, "owner@example.com", "x"));
+    PropertyEntity prop = propertyRepo.save(new PropertyEntity(null, "Prop", "addr", owner));
+    BookingEntity booking =
+        bookingRepo.save(
+            new BookingEntity(
+                null,
+                prop,
+                guest,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                BookingStatus.CONFIRMED));
+
+    // 3️⃣ خدمة الرسائل
     MessageService svc = new MessageService(messageRepo);
 
     MessageEntity msg =

--- a/services/backend/src/test/java/com/example/app/message/MessageServiceTest.java
+++ b/services/backend/src/test/java/com/example/app/message/MessageServiceTest.java
@@ -20,7 +20,8 @@ class MessageServiceTest {
 
   @Test
   void create_and_list_by_booking() {
-    UserEntity guest = userRepo.save(new UserEntity(null, null, "g@example.com", "x"));
+    UserEntity guest =
+        userRepo.save(new UserEntity(null, UserRole.GUEST, "g@example.com", "x"));
     BookingEntity booking =
         bookingRepo.save(new BookingEntity(null, null, guest, LocalDateTime.now(), LocalDateTime.now(), null));
 

--- a/services/backend/src/test/java/com/example/app/message/MessageServiceTest.java
+++ b/services/backend/src/test/java/com/example/app/message/MessageServiceTest.java
@@ -1,0 +1,38 @@
+package com.example.app.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.app.booking.BookingEntity;
+import com.example.app.booking.BookingRepository;
+import com.example.app.user.UserEntity;
+import com.example.app.user.UserRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class MessageServiceTest {
+
+  @Autowired MessageRepository messageRepo;
+  @Autowired BookingRepository bookingRepo;
+  @Autowired UserRepository userRepo;
+
+  @Test
+  void create_and_list_by_booking() {
+    UserEntity guest = userRepo.save(new UserEntity(null, null, "g@example.com", "x"));
+    BookingEntity booking =
+        bookingRepo.save(new BookingEntity(null, null, guest, LocalDateTime.now(), LocalDateTime.now(), null));
+
+    MessageService svc = new MessageService(messageRepo);
+
+    MessageEntity msg =
+        new MessageEntity(
+            null, booking, guest, "hello", LocalDateTime.now());
+
+    svc.create(msg);
+
+    assertThat(svc.list(booking.getId())).hasSize(1);
+    assertThat(svc.list(null)).hasSize(1);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MessageEntity` with booking and sender references
- define repository method for message queries and add service layer
- add migration to alter messages table with new columns
- clean up OpenAPI spec and include message endpoints
- include basic unit test for `MessageService`

## Testing
- `docker run --rm -v "$PWD":/local openapitools/openapi-generator-cli:v6.6.0 validate -i /local/services/backend/src/main/resources/openapi.yaml` *(fails: command not found)*
- `./scripts/generate.sh` *(fails: docker not found)*
- `pytest -q` *(fails: command not found)*
- `cd services/backend && ./mvnw flyway:clean flyway:migrate -q && ./mvnw clean verify -q` *(fails: could not download Maven)*