### PR TITLE
Add ordered message list

### DIFF
--- a/services/backend/src/main/java/com/example/app/message/MessageRepository.java
+++ b/services/backend/src/main/java/com/example/app/message/MessageRepository.java
@@ -6,4 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MessageRepository extends JpaRepository<MessageEntity, Long> {
 
   List<MessageEntity> findByBookingIdOrderBySentAtAsc(Long bookingId);
+
+  /** Returns all messages ordered by sentAt ascending. */
+  List<MessageEntity> findAllByOrderBySentAtAsc();
 }

--- a/services/backend/src/main/java/com/example/app/message/MessageService.java
+++ b/services/backend/src/main/java/com/example/app/message/MessageService.java
@@ -16,7 +16,7 @@ public class MessageService {
 
   public List<MessageEntity> list(Long bookingId) {
     if (bookingId == null) {
-      return messageRepository.findAll();
+      return messageRepository.findAllByOrderBySentAtAsc();
     }
     return messageRepository.findByBookingIdOrderBySentAtAsc(bookingId);
   }

--- a/services/backend/src/test/java/com/example/app/message/MessageControllerIntegrationTest.java
+++ b/services/backend/src/test/java/com/example/app/message/MessageControllerIntegrationTest.java
@@ -87,4 +87,39 @@ class MessageControllerIntegrationTest {
         .andExpect(jsonPath("$", Matchers.hasSize(1)))
         .andExpect(jsonPath("$[0].content").value("hello"));
   }
+
+  @Test
+  void getWithoutBookingIdOrdersBySentAt() throws Exception {
+    String msg1 =
+        """
+                {
+                  "bookingId": %d,
+                  "senderId": %d,
+                  "content": "later",
+                  "sentAt": "2024-01-01T13:00:00Z"
+                }
+                """
+            .formatted(bookingId, senderId);
+
+    String msg2 =
+        """
+                {
+                  "bookingId": %d,
+                  "senderId": %d,
+                  "content": "earlier",
+                  "sentAt": "2024-01-01T12:00:00Z"
+                }
+                """
+            .formatted(bookingId, senderId);
+
+    mockMvc.perform(post("/messages").contentType(MediaType.APPLICATION_JSON).content(msg1)).andExpect(status().isCreated());
+    mockMvc.perform(post("/messages").contentType(MediaType.APPLICATION_JSON).content(msg2)).andExpect(status().isCreated());
+
+    mockMvc
+        .perform(get("/messages"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", Matchers.hasSize(2)))
+        .andExpect(jsonPath("$[0].content").value("earlier"))
+        .andExpect(jsonPath("$[1].content").value("later"));
+  }
 }


### PR DESCRIPTION
## Summary
- order messages by sentAt
- expose new repository method to list ordered messages
- cover ordering in MessageControllerIntegrationTest

## Testing
- `pytest -q` *(fails: command not found)*
- `./services/backend/mvnw test -q` *(fails: cannot fetch Maven wrapper)*