### PR TITLE
Hash passwords on user creation

### DIFF
--- a/services/backend/src/main/java/com/example/app/user/UserService.java
+++ b/services/backend/src/main/java/com/example/app/user/UserService.java
@@ -17,6 +17,7 @@ public class UserService {
   }
 
   public UserEntity create(UserEntity user) {
+    user.setPasswordHash(passwordEncoder.encode(user.getPasswordHash()));
     return userRepository.save(user);
   }
 

--- a/services/backend/src/main/resources/db/migration/V11__rehash_plain_passwords.sql
+++ b/services/backend/src/main/resources/db/migration/V11__rehash_plain_passwords.sql
@@ -1,0 +1,4 @@
+UPDATE users
+SET password_hash = crypt(password_hash, gen_salt('bf'))
+WHERE length(password_hash) < 60; -- plain strings are < 60 chars, bcrypt ≥ 60
+


### PR DESCRIPTION
## Summary
- hash passwords during user creation
- rehash old plaintext passwords in a new migration

## Testing
- `pytest -q` *(fails: dependency 'PyYAML' missing)*
- `./mvnw test -q` in `services/backend` *(fails: unable to fetch Maven dependencies)*