### PR TITLE
Fix ApiClient DI snippets

### DIFF
--- a/apps/admin_app/README.md
+++ b/apps/admin_app/README.md
@@ -89,10 +89,15 @@ dev_dependencies:
 
 في `lib/core/di/service_locator.dart`:
 ```dart
-final getIt = GetIt.instance;
+final sl = GetIt.instance;
 
-void setupDependencies() {
-  getIt.registerLazySingleton<ApiClient>(() => ApiClient());
+Future<void> setupLocator() async {
+  final prefs = await SharedPreferences.getInstance();
+  sl.registerLazySingleton<ApiClient>(() {
+    final c = ApiClient();
+    c.setToken(prefs.getString('auth_token'));
+    return c;
+  });
   // خدمات أخرى
 }
 ```

--- a/apps/cleaner_app/README.md
+++ b/apps/cleaner_app/README.md
@@ -89,10 +89,15 @@ dev_dependencies:
 
 في `lib/core/di/service_locator.dart`:
 ```dart
-final getIt = GetIt.instance;
+final sl = GetIt.instance;
 
-void setupDependencies() {
-  getIt.registerLazySingleton<ApiClient>(() => ApiClient());
+Future<void> setupLocator() async {
+  final prefs = await SharedPreferences.getInstance();
+  sl.registerLazySingleton<ApiClient>(() {
+    final c = ApiClient();
+    c.setToken(prefs.getString('auth_token'));
+    return c;
+  });
   // خدمات أخرى
 }
 ```

--- a/apps/guest_app/README.md
+++ b/apps/guest_app/README.md
@@ -89,10 +89,15 @@ dev_dependencies:
 
 في `lib/core/di/service_locator.dart`:
 ```dart
-final getIt = GetIt.instance;
+final sl = GetIt.instance;
 
-void setupDependencies() {
-  getIt.registerLazySingleton<ApiClient>(() => ApiClient());
+Future<void> setupLocator() async {
+  final prefs = await SharedPreferences.getInstance();
+  sl.registerLazySingleton<ApiClient>(() {
+    final c = ApiClient();
+    c.setToken(prefs.getString('auth_token'));
+    return c;
+  });
   // خدمات أخرى
 }
 ```


### PR DESCRIPTION
## Summary
- update DI docs to use single ApiClient registration with token injection

## Testing
- `pytest -q` *(fails: dependency 'PyYAML' missing)*