### PR TITLE
Fix API path mismatch

### DIFF
--- a/services/backend/src/main/resources/application.properties
+++ b/services/backend/src/main/resources/application.properties
@@ -17,6 +17,7 @@ spring.security.user.name=demo
 
 # إذا تبغى كل الـ endpoints يكون `/api/...`
 #server.servlet.context-path=${openapi.pilotApp.base-path}
+spring.mvc.servlet.path=/api
 
 # SpringDoc (OpenAPI JSON & Swagger UI)
 springdoc.api-docs.path=/v3/api-docs


### PR DESCRIPTION
## Summary
- configure Spring to serve under `/api`

## Testing
- `pytest -q` *(fails: dependency 'PyYAML' missing)*
- `./mvnw test -q` in `services/backend` *(fails: cannot download Maven wrapper)*