### PR TITLE
Fix Java filter compile issue

### DIFF
--- a/services/backend/src/main/java/com/example/app/security/JwtAuthFilter.java
+++ b/services/backend/src/main/java/com/example/app/security/JwtAuthFilter.java
@@ -9,13 +9,10 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import io.jsonwebtoken.Claims;
-import java.util.List;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import com.example.app.user.UserEntity;
 import com.example.app.user.UserRepository;
@@ -49,14 +46,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         UsernamePasswordAuthenticationToken auth =
             new UsernamePasswordAuthenticationToken(subject, null, authorities);
-        Claims claims = tokenProvider.getClaims(token);
-        String subject = claims.getSubject();
-        String role = claims.get("role", String.class);
-        UsernamePasswordAuthenticationToken auth =
-            new UsernamePasswordAuthenticationToken(
-                subject,
-                null,
-                List.of(new SimpleGrantedAuthority("ROLE_" + role)));
         auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(auth);
       } catch (Exception e) {


### PR DESCRIPTION
## Summary
- fix duplicate variable declarations in JwtAuthFilter

## Testing
- `./mvnw -q clean verify` *(fails: could not download Maven)*
- `pytest -q` *(fails: missing PyYAML)*