### PR TITLE
Ensure requirements installed before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ Ensure you have a simulator or device ready (or use `-d` to specify one). The Fl
 
 ---
 ## Agent Guidelines
-See `AGENTS.md` for automated contributor rules. In short, run `pytest -q` before committing and regenerate OpenAPI clients with `./scripts/generate.sh` whenever you modify the spec.
+See `AGENTS.md` for automated contributor rules. In short, install dependencies with `pip install -r requirements.txt` and run `pytest -q` before committing. Regenerate OpenAPI clients with `./scripts/generate.sh` whenever you modify the spec.

--- a/scripts/apply_changes.py
+++ b/scripts/apply_changes.py
@@ -377,6 +377,7 @@ except (FileNotFoundError, sp.CalledProcessError) as exc:
 # ───────────────────────── 13. optional tests ────────────────────
 if args.run_tests:
     try:
+        _run(["pip", "install", "-r", "requirements.txt"], cwd=REPO_ROOT)
         _run(["pytest", "-q"], cwd=REPO_ROOT)
     except sp.CalledProcessError as exc:
         LOG.error("%s tests failed.", ERR)


### PR DESCRIPTION
## Summary
- mention installing requirements before tests
- install requirements in apply_changes when --run-tests is used

## Testing
- `pip install -r requirements.txt` *(fails: could not fetch from proxy)*
- `pytest -q` *(fails: dependency 'PyYAML' missing)*