### PR TITLE
Update CI python test setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: 📦 Install dependencies
+      - name: Install Python dependencies
         run: pip install -r requirements.txt
 
       - name: ✅ Run Pytest


### PR DESCRIPTION
## Summary
- run `pip install -r requirements.txt` with a clear step name in CI

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pyyaml>=6.0)*
- `pytest -q` *(fails: dependency 'PyYAML' missing)*