### PR TITLE
Fix pgcrypto requirement in migration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: 📦 Install dependencies
+      - name: Install Python dependencies
         run: pip install -r requirements.txt
 
       - name: ✅ Run Pytest

--- a/services/backend/src/main/resources/db/migration/V11__rehash_plain_passwords.sql
+++ b/services/backend/src/main/resources/db/migration/V11__rehash_plain_passwords.sql
@@ -1,3 +1,12 @@
+-- Ensure pgcrypto extension is available for bcrypt hashing
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto') THEN
+        CREATE EXTENSION pgcrypto;
+    END IF;
+END$$;
+
+-- Rehash any stored plain‑text passwords using bcrypt
 UPDATE users
 SET password_hash = crypt(password_hash, gen_salt('bf'))
 WHERE length(password_hash) < 60; -- plain strings are < 60 chars, bcrypt ≥ 60


### PR DESCRIPTION
## Summary
- ensure pgcrypto extension exists before rehashing passwords

## Testing
- `pytest -q` *(fails: dependency 'PyYAML' missing)*
- `./mvnw test -q` *(fails: could not download Maven)*
